### PR TITLE
docs(control-tower): refresh GAP_MAP near-term backlog

### DIFF
--- a/docs/controltower/GAP_MAP.md
+++ b/docs/controltower/GAP_MAP.md
@@ -45,9 +45,25 @@
 | Report builder + run | ✅ `/control-tower/reports`, `report-engine.ts`, run/summary/insight APIs | **`POST …/reports/run`** includes **`runSummary`** (`report-run-summary.ts`); builder shows a **scope strip** after each run. Insight LLM (`report-insight-llm.ts`): model JSON includes **dateFrom** / **dateTo** / **dateWindowLine** + **compareMeasure**; **`POST …/reports/insight`** returns **`runSummary`** on success and on **503** (LLM off/failure) so the scope card can render either way |
 | Saved reports + pin | ✅ Saved CRUD + dashboard widgets + modal drill | `GET …/dashboard/widgets` embeds **`runSummary`** on each **`report`** (same as `reports/run`); hub + **My dashboard** cards show date window / compare; modal insight UX matches report builder (**503** keeps scope card); **My dashboard** header links **Reporting hub** (`/reporting?focus=control-tower`) + report builder |
 | Search | ✅ `/control-tower/search` + `search-query.ts` + API + **`exceptionCode`** / **`alertType`** (open queue rows); **`GET …/search`** returns **`searchLimit`** / **`itemCount`** / **`truncated`** (default take **60**, max **200**); search page header links **Reporting hub** + **Workbench** | `list-shipments.ts`, assist **`exception:`** / **`ex:`**, **`alertType:`** / **`ctAlert:`** |
-| Assist | 🟡 Rule-based + optional LLM merge + **keyword retrieval** (`assist-retrieval.ts`: inbound, milestones, **milestone template packs**, exceptions, trace, schedules, **report AI insight**, **overview vs reports summary**, **`reporting-hub-focus`**, **CT search API**, routes, **saved workbench views**, dispatch, **shipment party fields**, **ops/escalation**, **CT cron jobs**, **forwarder booking**, **legs/containers/cargo**, **refs + sales order link**, **notes + finance snapshots/cost lines**, **customer digest** + **`/control-tower/digest`**, **documents/Blob**, **FX / display currency** → hints + `retrievedDocSnippets`) + **product trace** + **saved report + workbench names**; help playbooks **`control_tower`** (digest) + **`reporting_hub`** (**`focus`** step) | `assist.ts`, `assist-llm.ts`, `assist` API, `help-playbooks.ts` |
+| Assist | 🟡 Rule-based + optional LLM merge + **keyword retrieval** (`assist-retrieval.ts`: inbound, milestones, **milestone template packs**, exceptions, trace, schedules, **report AI insight**, **overview vs reports summary**, **`reporting-hub-focus`**, **CT search API**, routes, **saved workbench views**, dispatch, **shipment party fields**, **ops/escalation**, **CT cron jobs**, **forwarder booking**, **legs/containers/cargo**, **refs + sales order link**, **notes + finance snapshots/cost lines**, **customer digest** + **`/control-tower/digest`**, **documents/Blob**, **FX / display currency** → hints + `retrievedDocSnippets`) + **product trace** + **saved report + workbench names**; help playbooks **`control_tower`** (digest) + **`reporting_hub`** (**`focus`** step) | `assist.ts`, `assist-llm.ts`, `assist` API, `help-playbooks.ts`. **Gap vs PDF:** **Assist / chatbot — gap vs PDF** below + [issue #6](https://github.com/lasealco/po-management/issues/6). |
 | **Scheduled / emailed reports** | 🟡 Schedules + cron + Resend + **CSV + PDF** attachments; **Download CSV / PDF** on report builder (`report-csv.ts`, `report-pdf.ts`); PDF + **email subject/body** include **tenant / org** when known; PDF subtitle **measure · dimension** + optional **date window**; **plain-text body** mirrors **measure · dimension**, date window, and **compare measure** when set (`report-labels.ts`); **Reporting hub** (`/reporting`) Control Tower card links **Workbench** + **Shipment digest**; **Reporting** page header adds **Control Tower home** / **Workbench** / **Shipment digest** when **`org.controltower`** view | Richer layouts / spec parity still open |
-| **Full chatbot spec** (retrieval, tools, guardrails) | 🟡 Narrow assistant today | PDF `control_tower_search_and_chatbot_spec` |
+| **Full chatbot spec** (retrieval, tools, guardrails) | 🟡 Narrow assistant today | Parity target: **`control_tower_search_and_chatbot_spec_*.pdf`** (see [README](./README.md)). Same backlog as **Assist** — **Assist / chatbot — gap vs PDF** below, [issue #6](https://github.com/lasealco/po-management/issues/6). |
+
+### Assist / chatbot — gap vs PDF (`control_tower_search_and_chatbot_spec_*.pdf`)
+
+**Why this exists:** Issue [#6](https://github.com/lasealco/po-management/issues/6) asks for a **planning-readable** gap between today’s Control Tower **Assist** and the blueprint PDF **`control_tower_search_and_chatbot_spec_*.pdf`**, **without** pasting proprietary PDF text into the repo.
+
+**What exists today (runtime unchanged):** `POST /api/control-tower/assist` is a **tenant-scoped, grant-gated narrow assistant** — deterministic hints, optional LLM merge, **keyword** (non-embedding) retrieval assembled in `assist-retrieval.ts`, and help playbooks. Useful for operators; not, by itself, a full **multi-channel conversational chatbot** as enterprise PDFs often describe.
+
+**Spec parity checklist** (read the PDF for authoritative requirements; use this as a **triage list**, not a substitute):
+
+- **Retrieval** — Expect PDF-level depth to include **semantic / vector** retrieval (embeddings, chunking, re-ranking) over **approved** corpora plus operational data. Repo today: **keyword-scored** snippets from a curated map; no embedding index in this vertical yet.
+- **Tools** — Blueprints here usually assume **explicit tool contracts** (schemas, allowlists, human-in-the-loop). Repo today: assist **surfaces** actions, tokens, and deep links; confirm whether the PDF mandates **autonomous tool-calling loops** vs the current mostly **suggestive** pattern.
+- **Guardrails** — Map PDF expectations for **prompt injection**, **tenant / portal isolation** in any RAG path, **PII** minimization, and refusal behavior onto `assist-llm.ts` + retrieval sources before widening LLM exposure.
+- **Logging / telemetry** — If the PDF defines **trace IDs**, transcript retention, or model observability, compare to existing API logging + `CtAuditLog` usage and extend only where assist needs a **dedicated** audit story.
+- **Multi-turn / threads** — Specs often describe **chat sessions** (memory, compaction, replay of tool results). Current assist is closer to **per-request** context; closing the gap may require persistence + UI not present yet.
+- **Search integration** — `/control-tower/search` + `search-query.ts` are live; validate required **assist ↔ search** behaviors (query rewrite, explanations, ranking transparency) against the PDF.
+- **Portal / restricted sessions** — Customer digest + restricted portal chrome exist; any future retrieval/LLM work must preserve **grant-shaped answers** (internal vs portal), not only happy-path internal operators.
 
 ---
 
@@ -104,10 +120,34 @@ High-level groups: **references** · **tracking milestones** (+ pack apply) · *
 1. **Keep this file current** when merging Control Tower PRs (checkbox discipline).
 2. ~~**Exception catalog admin**~~ — ✅ Settings page + `GET /api/control-tower/exception-codes` + `upsert_ct_exception_code` POST action.
 3. ~~**Integration stub**~~ — 🟡 `POST /api/integrations/control-tower/inbound` + audit; **idempotent replays** (`idempotencyKey` + `INBOUND_WEBHOOK_EVENT` audit), **`generic_carrier_v1` / `carrier_webhook_v1` / `tms_event_v1` / `visibility_flat_v1`** + canonical milestone mapping, **`CtTrackingMilestone`** upsert — extend with carrier-specific mappers as needed (`carrier_webhook_v1` batch cap: env up to 200).
-4. **Assist / chatbot** — ~~saved CT reports + saved workbench filter names~~; ~~**keyword doc retrieval** (static corpus, no embeddings) for hints + LLM snippets~~; remaining: embeddings / vector search, fuller tool use vs PDF spec.
-5. **Reporting** — ~~CT schedules + email CSV/PDF + in-app Download CSV/PDF~~ (`pdf-lib` summary PDF); remaining: richer branded templates vs `control_tower_reporting_and_kpi_spec`.
-6. **Workbench** — ~~column prefs persistence~~ (localStorage + CSV respects visible columns); ~~cross-filter deep links~~ from Control Tower dashboard + executive cockpit (`controlTowerWorkbenchPath`, overdue ETA + status chips).
-7. **(Low priority)** **Report builder — exception / “NC” style analytics** — Today exceptions are first-class in workbench, search, Shipment 360, and catalog (`CtException` / `CtExceptionCode`), but **saved reports** only aggregate by logistics dimensions (status, lane, carrier, month, …). Later: extend `report-engine` with dimensions/measures such as **by exception `type`** (with catalog labels), **exception counts**, or **% shipments with open exceptions**; optional report filters mirroring `exceptionCode`. Unstructured **`rootCause`** or external reason/NC codes are better suited to detail export / AI insight unless normalized into a coded field.
+4. **Assist / chatbot** (vs **`control_tower_search_and_chatbot_spec_*.pdf`** — **§ Assist / chatbot — gap vs PDF** in **R3** + [issue #6](https://github.com/lasealco/po-management/issues/6))
+   - **Done:** rule-based routing + optional LLM merge; **keyword** doc retrieval (`assist-retrieval.ts`, static corpus, no embeddings) feeding hints + `retrievedDocSnippets`; saved **CT report** names + saved **workbench filter** names in assist payload; broad snippet set (search, schedules, cron routes, digest, parties, legs/cargo, etc.) — see **R3 Assist** row above; **gap checklist** for the next implementer lives in the **R3** subsection (issue **#6**).
+   - **Partial:** “narrow assistant” — no embedding / vector stage; no first-class **tool** layer (safe `POST /api/control-tower` actions from the model with guardrails) as in a full chatbot product.
+   - **Next smallest slice:** pick one vertical first — e.g. **vector or hosted embedding index** over the same doc corpus, **or** a minimal **tool schema** (read-only list + one or two audited mutations) behind a feature flag — before trying full spec parity.
+5. **Reporting templates** (vs `control_tower_reporting_and_kpi_spec`)
+   - **Done:** builder **run** + **runSummary** scope strip; **saved reports** + dashboard widgets + modal insight (**503** still returns scope); **email schedules** (cron + Resend) with **CSV + PDF** attachments; in-app **Download CSV / PDF**; shared **labels** (`report-labels.ts`) in PDF + plain-text email (measure · dimension, date window, compare).
+   - **Partial:** PDF/email are **tabular summary** layouts (`pdf-lib`), not marketing-grade branded packs or multi-section narrative KPI pages from the PDF.
+   - **Next smallest slice:** one **branded** PDF path (cover, typography, tenant logo hook) reused by schedule + Download PDF, then iterate sections — rather than a big-bang layout engine.
+6. **Workbench**
+   - **Done:** filters (incl. **open exception code** + **open alert type**), **saved views** (`CtSavedFilter`), **column visibility** (browser `localStorage` + optional **`columnVisibility` on saved view**), CSV export aligned to visible columns + **`# …` cap line** when truncated, **list cap** surfaced in UI, **deep links** from hub + executive + reports → `controlTowerWorkbenchPath` (status, overdue ETA, drills).
+   - **Partial / gap:** no **row multi-select** or **bulk** alert/exception/assign from the grid; column defaults do not sync as a first-class **per-user server profile** outside saved-view JSON.
+   - **Next smallest slice:** **multi-select + one bulk action** (e.g. acknowledge alerts or assign ops owner) with the same tenant scoping as single-row POST actions — or **server-stored default column visibility** per actor if ops consistency matters more than throughput.
+7. **(Low priority)** **Report builder — exception / “NC” style analytics**
+   - **Done elsewhere:** exceptions are first-class in **workbench**, **search**, **Shipment 360**, and **exception catalog** (`CtException` / `CtExceptionCode`); list/search APIs accept **`exceptionCode`** / **`alertType`** for open-queue style cuts.
+   - **Not in `report-engine` today:** dimensions are **`none` · status · mode · lane · carrier · customer · supplier · origin · destination · month`** only (`CT_REPORT_DIMENSIONS` in `report-engine.ts`) — no **exception code / type** bucket, no **% with open exception** measure.
+   - **Next smallest slice:** add **`exceptionCode`** (catalog label join) as a **dimension** *or* one aggregate measure (**open exception count** / **shipments with open exception**), plus optional **report filter** mirroring workbench `exceptionCode` — before unstructured **rootCause** / external NC codes (better for export + AI insight unless normalized).
+
+---
+
+## Suggested next PRs
+
+File each bullet as its own GitHub issue when you pull it into a sprint (titles are suggestions; scope should stay one vertical per PR).
+
+- **`[tower] Assist: embedding-backed retrieval`** — Vector or managed embeddings over the existing assist corpus + feature flag; keep keyword retrieval as fallback.
+- **`[tower] Assist: audited tool calls for Control Tower POST actions`** — Small allowlisted mutation set + schema for the LLM path; explicit operator confirmation in UI where needed.
+- **`[tower] Reporting: branded PDF / email template pass`** — First branded layout pass shared by schedule attachment + Download PDF (logo/tenant line, typography), then iterate toward KPI spec sections.
+- **`[tower] Workbench: multi-select + bulk operator action`** — e.g. bulk alert ack or bulk assignee, reusing tenant scope and existing `POST /api/control-tower` patterns.
+- **`[tower] Report engine: exception-aware dimensions / measures`** — Extend `report-engine` + builder UI with exception catalog labels and/or “open exception rate” style measures; optional `exceptionCode` filter parity with workbench.
 
 ---
 
@@ -115,6 +155,8 @@ High-level groups: **references** · **tracking milestones** (+ pack apply) · *
 
 | Date | Change |
 |------|--------|
+| 2026-04-20 | Near-term **4–7** refreshed (done / partial / next slice); added **Suggested next PRs**; tracking issue [#3](https://github.com/lasealco/po-management/issues/3). |
+| 2026-04-20 | **R3 Assist / chatbot:** gap narrative + **spec parity checklist** vs **`control_tower_search_and_chatbot_spec_*.pdf`** (rows + **§** subsection); [issue #6](https://github.com/lasealco/po-management/issues/6). |
 | 2026-04-18 | Backlog **#7 (low priority)**: report builder exception / NC-style analytics (deferred; workbench + 360 already cover triage). |
 | 2026-04-17 | Initial `GAP_MAP.md` + `README.md`. Implemented **Settings → Control Tower exception types** + `exception-codes` GET + `upsert_ct_exception_code` POST action. |
 | 2026-04-17 | Control Tower inbound webhook stub; workbench **table column** prefs + CSV alignment; assist `supplier:` / `customer:` cuid filters + search API support. |


### PR DESCRIPTION
## Summary
Updates `docs/controltower/GAP_MAP.md` per [issue #3](https://github.com/lasealco/po-management/issues/3): near-term items **4–7** rewritten with **done / partial / next smallest slice**, aligned with current code (including `CT_REPORT_DIMENSIONS` in `report-engine.ts`). Adds **Suggested next PRs** (five scoped follow-up issue titles). Changelog links issue #3.

Also completes [issue #6](https://github.com/lasealco/po-management/issues/6): **R3 Assist / chatbot** rows link the gap to **`control_tower_search_and_chatbot_spec_*.pdf`**; new **§ Assist / chatbot — gap vs PDF** subsection (planning narrative + spec parity checklist: retrieval, tools, guardrails, logging, multi-turn, search, portal); backlog item **4** and changelog cross-link issue #6. No runtime code changes.

## Scope
- Docs only — `docs/controltower/GAP_MAP.md`

## Verify
- `npm run lint` (warnings only, pre-existing)
- `npx tsc --noEmit`
- `npm run test`

Closes #3
Closes #6

Made with [Cursor](https://cursor.com)