### PR TITLE
docs(controltower): refresh GAP_MAP for issue #3

### DIFF
--- a/docs/controltower/GAP_MAP.md
+++ b/docs/controltower/GAP_MAP.md
@@ -117,37 +117,39 @@ High-level groups: **references** · **tracking milestones** (+ pack apply) · *
 
 ## Near-term build order (engineering backlog)
 
+Use this list when slicing PRs; refresh it whenever Control Tower behavior or `report-engine` contracts change ([issue #3](https://github.com/lasealco/po-management/issues/3)). **1–3** are hygiene plus already-shipped foundations; **4–7** are the active near-term product gaps.
+
 1. **Keep this file current** when merging Control Tower PRs (checkbox discipline).
 2. ~~**Exception catalog admin**~~ — ✅ Settings page + `GET /api/control-tower/exception-codes` + `upsert_ct_exception_code` POST action.
 3. ~~**Integration stub**~~ — 🟡 `POST /api/integrations/control-tower/inbound` + audit; **idempotent replays** (`idempotencyKey` + `INBOUND_WEBHOOK_EVENT` audit), **`generic_carrier_v1` / `carrier_webhook_v1` / `tms_event_v1` / `visibility_flat_v1`** + canonical milestone mapping, **`CtTrackingMilestone`** upsert — extend with carrier-specific mappers as needed (`carrier_webhook_v1` batch cap: env up to 200).
-4. **Assist / chatbot** (vs **`control_tower_search_and_chatbot_spec_*.pdf`** — **§ Assist / chatbot — gap vs PDF** in **R3** + [issue #6](https://github.com/lasealco/po-management/issues/6))
-   - **Done:** rule-based routing + optional LLM merge; **keyword** doc retrieval (`assist-retrieval.ts`, static corpus, no embeddings) feeding hints + `retrievedDocSnippets`; saved **CT report** names + saved **workbench filter** names in assist payload; broad snippet set (search, schedules, cron routes, digest, parties, legs/cargo, etc.) — see **R3 Assist** row above; **gap checklist** for the next implementer lives in the **R3** subsection (issue **#6**).
-   - **Partial:** “narrow assistant” — no embedding / vector stage; no first-class **tool** layer (safe `POST /api/control-tower` actions from the model with guardrails) as in a full chatbot product.
-   - **Next smallest slice:** pick one vertical first — e.g. **vector or hosted embedding index** over the same doc corpus, **or** a minimal **tool schema** (read-only list + one or two audited mutations) behind a feature flag — before trying full spec parity.
+4. **Assist / chatbot** (vs **`control_tower_search_and_chatbot_spec_*.pdf`** — **Assist / chatbot — gap vs PDF** subsection under **R3** + [issue #6](https://github.com/lasealco/po-management/issues/6))
+   - **Done:** rule-based routing + optional LLM merge; **keyword-only** doc retrieval (`assist-retrieval.ts` — no embedding index in this vertical) feeding hints + `retrievedDocSnippets`; saved **CT report** names + saved **workbench filter** names in assist payload; broad snippet set (search, schedules, cron routes, digest, parties, legs/cargo, etc.) — see **R3 Assist** row above; **gap checklist** for the next implementer lives in the **R3** subsection (issue **#6**).
+   - **Partial:** **per-request** assistant, not threaded chat sessions; no **semantic / vector** retrieval stage; no allowlisted **tool-calling** loop that executes `POST /api/control-tower` actions with operator confirmation — today the model path is mostly **suggestive** (deep links + hints), not autonomous agent loops.
+   - **Next smallest slice:** pick **one** vertical first — **embedding-backed retrieval** over the same corpus (feature-flagged, keyword fallback) **or** a **minimal tool schema** (read-only list + one or two audited mutations with explicit UI confirm) — before chasing full PDF parity.
 5. **Reporting templates** (vs `control_tower_reporting_and_kpi_spec`)
-   - **Done:** builder **run** + **runSummary** scope strip; **saved reports** + dashboard widgets + modal insight (**503** still returns scope); **email schedules** (cron + Resend) with **CSV + PDF** attachments; in-app **Download CSV / PDF**; shared **labels** (`report-labels.ts`) in PDF + plain-text email (measure · dimension, date window, compare).
-   - **Partial:** PDF/email are **tabular summary** layouts (`pdf-lib`), not marketing-grade branded packs or multi-section narrative KPI pages from the PDF.
-   - **Next smallest slice:** one **branded** PDF path (cover, typography, tenant logo hook) reused by schedule + Download PDF, then iterate sections — rather than a big-bang layout engine.
+   - **Done:** builder **run** + **runSummary** scope strip; **saved reports** + dashboard widgets + modal insight (**503** still returns scope); **email schedules** (cron + Resend) with **CSV + PDF** attachments; in-app **Download CSV / PDF**; shared **labels** (`report-labels.ts`) in PDF + plain-text email (measure · dimension, date window, compare); PDF **`organizationLabel`** path (`report-pdf.ts`) — tenant/org line on cover + footer tagline + per-page corner (builder + schedule cron pass tenant name when known).
+   - **Partial:** layout is still a **single tabular narrative** (`pdf-lib` + Helvetica), not a **logo-driven template pack**, multi-section executive KPI story, or pixel-faithful spec layouts from the PDF.
+   - **Next smallest slice:** **raster logo hook** (tenant URL or upload) + typography / spacing tokens on the same PDF builder, reused by schedule + Download PDF — then add sections incrementally instead of a layout engine rewrite.
 6. **Workbench**
    - **Done:** filters (incl. **open exception code** + **open alert type**), **saved views** (`CtSavedFilter`), **column visibility** (browser `localStorage` + optional **`columnVisibility` on saved view**), CSV export aligned to visible columns + **`# …` cap line** when truncated, **list cap** surfaced in UI, **deep links** from hub + executive + reports → `controlTowerWorkbenchPath` (status, overdue ETA, drills).
-   - **Partial / gap:** no **row multi-select** or **bulk** alert/exception/assign from the grid; column defaults do not sync as a first-class **per-user server profile** outside saved-view JSON.
-   - **Next smallest slice:** **multi-select + one bulk action** (e.g. acknowledge alerts or assign ops owner) with the same tenant scoping as single-row POST actions — or **server-stored default column visibility** per actor if ops consistency matters more than throughput.
+   - **Partial / gap:** no **row multi-select** or **bulk** alert/exception/assign from the grid; no **server-stored default column visibility** per actor outside **`columnVisibility` inside saved-view JSON**.
+   - **Next smallest slice:** **multi-select + one bulk action** (e.g. acknowledge alerts or assign ops owner) with the same tenant scoping as single-row POST actions — **or** **server-stored default column visibility** per actor if ops consistency matters more than throughput.
 7. **(Low priority)** **Report builder — exception / “NC” style analytics**
    - **Done elsewhere:** exceptions are first-class in **workbench**, **search**, **Shipment 360**, and **exception catalog** (`CtException` / `CtExceptionCode`); list/search APIs accept **`exceptionCode`** / **`alertType`** for open-queue style cuts.
-   - **Not in `report-engine` today:** dimensions are **`none` · status · mode · lane · carrier · customer · supplier · origin · destination · month`** only (`CT_REPORT_DIMENSIONS` in `report-engine.ts`) — no **exception code / type** bucket, no **% with open exception** measure.
+   - **Not in `report-engine` today:** `CT_REPORT_DIMENSIONS` is exactly **`none` · `status` · `mode` · `lane` · `carrier` · `customer` · `supplier` · `origin` · `destination` · `month`** (`report-engine.ts`) — no **exception code / type** dimension, no **open-exception rate** or **shipments-with-open-exception** measure in `CT_REPORT_MEASURES`.
    - **Next smallest slice:** add **`exceptionCode`** (catalog label join) as a **dimension** *or* one aggregate measure (**open exception count** / **shipments with open exception**), plus optional **report filter** mirroring workbench `exceptionCode` — before unstructured **rootCause** / external NC codes (better for export + AI insight unless normalized).
 
 ---
 
 ## Suggested next PRs
 
-File each bullet as its own GitHub issue when you pull it into a sprint (titles are suggestions; scope should stay one vertical per PR).
+File **one GitHub issue per bullet** when scheduling (titles are suggestions; keep each PR to a single vertical). Order mirrors backlog **#4 → #7** above.
 
-- **`[tower] Assist: embedding-backed retrieval`** — Vector or managed embeddings over the existing assist corpus + feature flag; keep keyword retrieval as fallback.
+- **`[tower] Assist: embedding-backed retrieval`** — Vector or managed embeddings over the existing assist corpus + feature flag; keep keyword retrieval as fallback (closes the largest **Assist / chatbot** retrieval gap).
 - **`[tower] Assist: audited tool calls for Control Tower POST actions`** — Small allowlisted mutation set + schema for the LLM path; explicit operator confirmation in UI where needed.
-- **`[tower] Reporting: branded PDF / email template pass`** — First branded layout pass shared by schedule attachment + Download PDF (logo/tenant line, typography), then iterate toward KPI spec sections.
+- **`[tower] Reporting: logo + typography pass on tabular PDF`** — Raster logo hook + spacing/typography tokens on `report-pdf.ts`, shared by schedule attachment + Download PDF; then iterate KPI spec sections.
 - **`[tower] Workbench: multi-select + bulk operator action`** — e.g. bulk alert ack or bulk assignee, reusing tenant scope and existing `POST /api/control-tower` patterns.
-- **`[tower] Report engine: exception-aware dimensions / measures`** — Extend `report-engine` + builder UI with exception catalog labels and/or “open exception rate” style measures; optional `exceptionCode` filter parity with workbench.
+- **`[tower] Report engine: exception-aware dimensions / measures`** — Extend `report-engine.ts` + builder UI with exception catalog labels and/or “open exception rate” style measures; optional `exceptionCode` filter parity with workbench.
 
 ---
 
@@ -155,8 +157,8 @@ File each bullet as its own GitHub issue when you pull it into a sprint (titles 
 
 | Date | Change |
 |------|--------|
-| 2026-04-20 | Near-term **4–7** refreshed (done / partial / next slice); added **Suggested next PRs**; tracking issue [#3](https://github.com/lasealco/po-management/issues/3). |
-| 2026-04-20 | **R3 Assist / chatbot:** gap narrative + **spec parity checklist** vs **`control_tower_search_and_chatbot_spec_*.pdf`** (rows + **§** subsection); [issue #6](https://github.com/lasealco/po-management/issues/6). |
+| 2026-04-20 | Near-term **4–7** re-checked against code (`report-engine` dimensions, `report-pdf` org line, workbench single-select); tightened Done/Partial/Next; **Suggested next PRs** aligned to **#4–7**; tracking [issue #3](https://github.com/lasealco/po-management/issues/3). |
+| 2026-04-20 | **R3 Assist / chatbot:** gap narrative + **spec parity checklist** vs **`control_tower_search_and_chatbot_spec_*.pdf`** (rows + dedicated subsection); [issue #6](https://github.com/lasealco/po-management/issues/6). |
 | 2026-04-18 | Backlog **#7 (low priority)**: report builder exception / NC-style analytics (deferred; workbench + 360 already cover triage). |
 | 2026-04-17 | Initial `GAP_MAP.md` + `README.md`. Implemented **Settings → Control Tower exception types** + `exception-codes` GET + `upsert_ct_exception_code` POST action. |
 | 2026-04-17 | Control Tower inbound webhook stub; workbench **table column** prefs + CSV alignment; assist `supplier:` / `customer:` cuid filters + search API support. |

--- a/docs/engineering/agent-todos/README.md
+++ b/docs/engineering/agent-todos/README.md
@@ -31,3 +31,4 @@ These files turn **module backlogs** into **checkbox queues** for Cursor (or clo
 ## Related
 
 - [Multi-session and agents](../multi-session-and-agents.md) — branches, seeds, CI checks.
+- [Meeting-batch epics](../meeting-epics/README.md) — **~2h+** scoped GitHub issues for parallel agents.

--- a/docs/engineering/meeting-epics/README.md
+++ b/docs/engineering/meeting-epics/README.md
@@ -1,0 +1,26 @@
+# Meeting-batch GitHub issues (long-running agent scope)
+
+These markdown files are the **source bodies** for fat issues meant for **~2+ hours** of agent work each (wall time **not guaranteed** — scope is what creates depth).
+
+## Active meeting batches
+
+| Module | GitHub issue | Body file |
+|--------|----------------|-----------|
+| Control Tower | [#9](https://github.com/lasealco/po-management/issues/9) | [`_gh-issue-body-tower-meeting.md`](./_gh-issue-body-tower-meeting.md) |
+| CRM | [#10](https://github.com/lasealco/po-management/issues/10) | [`_gh-issue-body-crm-meeting.md`](./_gh-issue-body-crm-meeting.md) |
+| WMS | [#11](https://github.com/lasealco/po-management/issues/11) | [`_gh-issue-body-wms-meeting.md`](./_gh-issue-body-wms-meeting.md) |
+| Tariff | [#12](https://github.com/lasealco/po-management/issues/12) | [`_gh-issue-body-tariff-meeting.md`](./_gh-issue-body-tariff-meeting.md) |
+
+**Parallel rule:** start **at most one agent per issue**, each on **different module paths** (these four are designed **not** to overlap).
+
+## Copy-paste agent starter (per window)
+
+```text
+Repo: lasealco/po-management (this workspace). Implement GitHub issue #___ only.
+Read the full issue body + every comment. Complete every unchecked checkbox in order.
+Branch from main; one PR; do not merge to main.
+Do not run db:seed or db:migrate unless the issue explicitly says so — if blocked, stop and ask Alex.
+If a step is larger than expected, finish the current checkbox, commit, push, then continue on the same branch in the same chat with "continue with the next checkbox".
+```
+
+Replace `#___` with **9**, **10**, **11**, or **12**.

--- a/docs/engineering/meeting-epics/_gh-issue-body-crm-meeting.md
+++ b/docs/engineering/meeting-epics/_gh-issue-body-crm-meeting.md
@@ -1,0 +1,33 @@
+## Goal (meeting batch — CRM)
+
+Ship a **visible CRM slice**: opportunities UX + quote detail depth. Target **~2+ hours** (scope is multi-file).
+
+## Scope (allowed)
+
+- `src/components/crm-opportunities-list.tsx` (and tiny types only if colocated)
+- `src/app/crm/opportunities/**`
+- `src/components/crm-quote-detail.tsx` or quote detail under `src/components/crm-*` / `src/app/crm/quotes/**` (only files that already relate to quote detail)
+- `src/app/api/crm/**` **only** for read-only list endpoints if missing (prefer **no** new migrations; use existing `CrmQuoteLine` access patterns from `src/app/api/crm/quotes/[id]/lines/route.ts`)
+
+## Do **not**
+
+- Control Tower, WMS, tariff, SRM routes
+- `db:seed` / `db:migrate` unless you hit a **blocking** schema gap — **stop and ask Alex** first
+
+## Checklist (complete all)
+
+- [ ] **Opportunities list:** add **stage** and **owner** (or **text search**) filters with **URL query sync** (`?stage=&owner=` or your choice) so links are shareable; preserve existing columns.
+- [ ] **Opportunities list:** empty / error / loading states polished (match existing CRM styling).
+- [ ] **Quote detail:** show **line items** in a read-only table (description, qty, unit price, line total if fields exist on `CrmQuoteLine`); load via existing CRM APIs (`GET …/quotes/[id]/lines` or equivalent already in repo — **discover and reuse**, do not duplicate business logic).
+- [ ] **Quote detail:** clear “add line” affordance may stay **link to existing edit flow** if full inline edit is out of scope — document in PR if so.
+- [ ] **Tests:** add **Vitest** for any **new pure helpers** (e.g. query-string builders) in `src/lib/crm/**` if you extract them; if no pure helpers, add **one** minimal component test only if the repo already has that pattern for CRM — otherwise skip and note why.
+- [ ] **Green gate:** `npm run lint && npx tsc --noEmit && npm run test`
+
+## Git
+
+- Branch from `main`; one PR; do not merge.
+
+## Ref
+
+- `docs/engineering/agent-todos/crm.md`
+- `docs/crm/BACKLOG.md`

--- a/docs/engineering/meeting-epics/_gh-issue-body-tariff-meeting.md
+++ b/docs/engineering/meeting-epics/_gh-issue-body-tariff-meeting.md
@@ -1,0 +1,34 @@
+## Goal (meeting batch — Tariff engine slice)
+
+**Regression + polish** inside the tariff vertical. Target **~2+ hours**. Follow **`.cursor/rules/tariff-engine-scope.mdc`**.
+
+## Scope (allowed)
+
+Only paths under the tariff engine slice, for example:
+
+- `src/lib/tariff/**`
+- `src/app/tariffs/**`
+- `src/app/api/tariffs/**`
+- `src/components/tariffs/**`
+
+(Plus invoice-audit / pricing-snapshot paths **only** if the issue explicitly lists them — **do not** for this batch unless you found a blocking bug.)
+
+## Do **not**
+
+- Control Tower, CRM, WMS, SRM, unrelated `app-nav` refactors
+- `db:seed` / `db:migrate` — **stop and ask Alex** if you believe they are required
+
+## Checklist (complete all)
+
+- [ ] **Tests:** add or extend **Vitest** coverage for **two** of: `import-pipeline.ts`, `promote-import-body.ts`, `geography-catalog.ts`, `tariff-workbench-urls.ts` (pick files with lowest coverage / highest churn — justify in PR).
+- [ ] **Import UI:** one **operator-visible** improvement on `src/app/tariffs/import/**` or `tariff-import-*` components (clearer error state, step header alignment with workflow design token `var(--arscmp-primary)` for primary button if you add a CTA — see `.cursor/rules/workflow-design-system.mdc`).
+- [ ] **Pure helpers:** if you extract helpers for tests, keep them in `src/lib/tariff/**`.
+- [ ] **Green gate:** `npm run verify:tariff-engine`
+
+## Git
+
+- Branch from `main`; one PR; do not merge.
+
+## Ref
+
+- `docs/engineering/agent-todos/tariff.md`

--- a/docs/engineering/meeting-epics/_gh-issue-body-tower-meeting.md
+++ b/docs/engineering/meeting-epics/_gh-issue-body-tower-meeting.md
@@ -1,0 +1,31 @@
+## Goal (meeting batch — Control Tower)
+
+Substantive **tests + small hardening** for inbound integration logic. Target **~2+ hours** of focused work (may finish faster or need a follow-up message if CI surfaces edge cases).
+
+## Scope (allowed)
+
+- `src/lib/control-tower/inbound-webhook.ts` (small refactors **only** if required for testability — keep behavior identical unless fixing a proven bug uncovered by tests)
+- **New** `src/lib/control-tower/inbound-webhook.test.ts` (or split `*.test.ts` files next to the lib)
+- Optional: `docs/controltower/GAP_MAP.md` **changelog line only** for this PR
+
+## Do **not**
+
+- `db:seed`, `db:migrate`, or Prisma schema changes
+- Other modules, global nav, unrelated APIs
+
+## Checklist (complete all)
+
+- [ ] **Idempotency:** tests for `idempotencyKey` replay vs first-time processing (match current audit / status semantics).
+- [ ] **Batch cap:** tests for `carrier_webhook_v1` `data[]` length vs `getMaxCarrierWebhookRows()` / `maxBatchRows` in JSON.
+- [ ] **Formats:** at least one happy-path test each for **`generic_carrier_v1`**, **`visibility_flat_v1`**, **`tms_event_v1`** (minimal payloads; use fixtures inline).
+- [ ] **Errors:** at least two tests for **400** paths you can trigger without DB (invalid payload shape / missing shipment id) — mock Prisma where needed.
+- [ ] **Green gate:** `npm run lint && npx tsc --noEmit && npm run test`
+
+## Git
+
+- Branch from `main`; one PR; do not merge.
+
+## Ref
+
+- GitHub **#4** (narrower); this epic supersedes for the meeting batch if you use this issue number instead.
+- `docs/controltower/GAP_MAP.md` R4 inbound webhooks

--- a/docs/engineering/meeting-epics/_gh-issue-body-wms-meeting.md
+++ b/docs/engineering/meeting-epics/_gh-issue-body-wms-meeting.md
@@ -1,0 +1,32 @@
+## Goal (meeting batch — WMS)
+
+Deepen **stock / movement** operator UX and add **regression tests** for pure helpers. Target **~2+ hours**.
+
+## Scope (allowed)
+
+- `src/app/wms/stock/**`
+- `src/components/wms-*` files that are **only** used by stock / movement UI (discover via imports from stock page)
+- `src/lib/wms/**` for small extracted helpers + tests
+
+## Do **not**
+
+- CRM, Control Tower, tariff
+- `db:seed` / `db:migrate` — **stop and ask** if schema changes seem required
+
+## Checklist (complete all)
+
+- [ ] **Movement ledger UX:** add **preset chips** or a **quick filter row** for common `mvType` values (reuse existing query param contract from stock page — read current implementation first).
+- [ ] **URL / shareability:** ensure filter choices sync to the URL so operators can share links (if not already).
+- [ ] **CSV export:** confirm export reflects **visible** filtered ledger rows; fix if a mismatch is found; document behavior in PR.
+- [ ] **Edge states:** empty ledger, truncated cap message (if server returns truncation), and error banner consistency.
+- [ ] **Tests:** add **Vitest** for **one** extracted pure function (e.g. building query strings, normalizing filter params, or formatting movement type labels) in `src/lib/wms/**`.
+- [ ] **Green gate:** `npm run lint && npx tsc --noEmit && npm run test`
+
+## Git
+
+- Branch from `main`; one PR; do not merge.
+
+## Ref
+
+- `docs/wms/GAP_MAP.md`
+- `docs/engineering/agent-todos/wms.md`


### PR DESCRIPTION
Closes https://github.com/lasealco/po-management/issues/3

## Summary
- Re-read **Near-term build order** against current `report-engine`, `report-pdf`, assist, and workbench reality.
- Tightened **items 4–7** (Assist, Reporting templates, Workbench, Exception analytics): clearer Done / Partial / next smallest slice.
- **Suggested next PRs**: kept five bullets, aligned order to backlog **#4–#7** and sharpened the reporting PDF issue to match what is already shipped (org line) vs what is still open (logo + typography).
- Changelog + subsection cross-refs updated; removed `§` markers per doc style.

## Scope
- `docs/controltower/GAP_MAP.md` only (no app code).

Made with [Cursor](https://cursor.com)