### PR TITLE
feat(crm): issue #10 — opportunities URL filters + quote line table

### DIFF
--- a/src/components/crm-opportunities-list.tsx
+++ b/src/components/crm-opportunities-list.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  buildOpportunitiesListSearch,
+  parseOpportunitiesListQuery,
+} from "@/lib/crm/opportunities-list-query";
 
 type OppRow = {
   id: string;
@@ -13,7 +18,7 @@ type OppRow = {
   nextStepDate: string | null;
   nextStep: string | null;
   account: { id: string; name: string };
-  owner: { name: string };
+  owner: { id: string; name: string };
 };
 
 const STAGES = [
@@ -30,17 +35,56 @@ const STAGES = [
   "ON_HOLD",
 ] as const;
 
+const SEARCH_DEBOUNCE_MS = 400;
+
 export function CrmOpportunitiesList() {
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const staleOnly = searchParams.get("stale") === "1";
+
+  const { stage: stageFilter, owner: ownerFilter, q: qFromUrl, stale: staleOnly } = useMemo(
+    () => parseOpportunitiesListQuery(searchParams),
+    [searchParams],
+  );
 
   const [rows, setRows] = useState<OppRow[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [stageFilter, setStageFilter] = useState<string>("");
-  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [qDraft, setQDraft] = useState(qFromUrl);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setQDraft(qFromUrl);
+  }, [qFromUrl]);
+
+  const replaceListQuery = useCallback(
+    (patch: Partial<{ stage: string; owner: string; q: string }>) => {
+      const nextQs = buildOpportunitiesListSearch(new URLSearchParams(searchParams.toString()), patch);
+      router.replace(nextQs ? `${pathname}?${nextQs}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const onSearchInput = useCallback(
+    (value: string) => {
+      setQDraft(value);
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+      searchDebounceRef.current = setTimeout(() => {
+        replaceListQuery({ q: value });
+      }, SEARCH_DEBOUNCE_MS);
+    },
+    [replaceListQuery],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, []);
 
   const load = useCallback(async () => {
     setError(null);
+    setLoading(true);
     try {
       const res = await fetch("/api/crm/opportunities");
       const data = await res.json();
@@ -48,6 +92,8 @@ export function CrmOpportunitiesList() {
       setRows(data.opportunities ?? []);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
     }
   }, []);
 
@@ -55,13 +101,27 @@ export function CrmOpportunitiesList() {
     void load();
   }, [load]);
 
+  const ownerOptions = useMemo(() => {
+    const byId = new Map<string, string>();
+    for (const r of rows) {
+      if (!byId.has(r.owner.id)) byId.set(r.owner.id, r.owner.name);
+    }
+    return [...byId.entries()]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [rows]);
+
+  const ownerSelectValue =
+    !ownerFilter || ownerOptions.some((o) => o.id === ownerFilter) ? ownerFilter : "";
+
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
+    const q = qDraft.trim().toLowerCase();
     const startOfToday = new Date();
     startOfToday.setUTCHours(0, 0, 0, 0);
     const terminal = new Set(["LOST", "WON_LIVE"]);
     return rows.filter((r) => {
       if (stageFilter && r.stage !== stageFilter) return false;
+      if (ownerFilter && r.owner.id !== ownerFilter) return false;
       if (staleOnly) {
         if (terminal.has(r.stage)) return false;
         const cd = r.closeDate ? new Date(r.closeDate) : null;
@@ -74,10 +134,24 @@ export function CrmOpportunitiesList() {
       return (
         r.name.toLowerCase().includes(q) ||
         r.account.name.toLowerCase().includes(q) ||
-        r.stage.toLowerCase().includes(q)
+        r.stage.toLowerCase().includes(q) ||
+        r.owner.name.toLowerCase().includes(q)
       );
     });
-  }, [rows, stageFilter, query, staleOnly]);
+  }, [rows, stageFilter, ownerFilter, qDraft, staleOnly]);
+
+  const hasActiveFilters =
+    Boolean(stageFilter) || Boolean(ownerFilter) || Boolean(qDraft.trim()) || staleOnly;
+
+  const clearFiltersHref = useMemo(() => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete("stage");
+    next.delete("owner");
+    next.delete("q");
+    next.delete("stale");
+    const qs = next.toString();
+    return qs ? `${pathname}?${qs}` : pathname;
+  }, [pathname, searchParams]);
 
   return (
     <div className="mx-auto max-w-7xl px-6 py-8">
@@ -95,19 +169,20 @@ export function CrmOpportunitiesList() {
         <button
           type="button"
           onClick={() => void load()}
-          className="self-start rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-800 hover:bg-zinc-50"
+          disabled={loading}
+          className="self-start rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-800 hover:bg-zinc-50 disabled:opacity-50"
         >
-          Refresh
+          {loading ? "Refreshing…" : "Refresh"}
         </button>
       </div>
 
-      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end">
-        <label className="text-sm sm:w-64">
-          <span className="text-zinc-600">Stage</span>
+      <div className="mb-4 grid gap-3 rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm sm:grid-cols-3">
+        <label className="text-sm">
+          <span className="font-medium text-zinc-700">Stage</span>
           <select
             value={stageFilter}
-            onChange={(e) => setStageFilter(e.target.value)}
-            className="mt-1 w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+            onChange={(e) => replaceListQuery({ stage: e.target.value })}
+            className="mt-1 w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900"
           >
             <option value="">All stages</option>
             {STAGES.map((s) => (
@@ -117,25 +192,51 @@ export function CrmOpportunitiesList() {
             ))}
           </select>
         </label>
-        <label className="flex-1 text-sm">
-          <span className="text-zinc-600">Search</span>
+        <label className="text-sm">
+          <span className="font-medium text-zinc-700">Owner</span>
+          <select
+            value={ownerSelectValue}
+            onChange={(e) => replaceListQuery({ owner: e.target.value })}
+            className="mt-1 w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900"
+          >
+            <option value="">All owners</option>
+            {ownerOptions.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-sm sm:col-span-1">
+          <span className="font-medium text-zinc-700">Search</span>
           <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Name, account, or stage"
-            className="mt-1 w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+            value={qDraft}
+            onChange={(e) => onSearchInput(e.target.value)}
+            placeholder="Name, account, stage, or owner"
+            className="mt-1 w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400"
           />
         </label>
       </div>
 
       {error ? (
-        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-900">
-          {error}
+        <div
+          className="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-4 shadow-sm"
+          role="alert"
+        >
+          <p className="text-sm font-medium text-red-900">Could not load opportunities</p>
+          <p className="mt-1 text-sm text-red-800">{error}</p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="mt-3 rounded-lg border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-900 hover:bg-red-100"
+          >
+            Try again
+          </button>
         </div>
       ) : null}
 
       {staleOnly ? (
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-950">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 shadow-sm">
           <span>
             Showing opportunities whose close date or next-step date is before today (UTC).
           </span>
@@ -143,72 +244,112 @@ export function CrmOpportunitiesList() {
             href="/crm/opportunities"
             className="shrink-0 font-medium text-violet-800 underline-offset-2 hover:underline"
           >
-            Clear filter
+            Clear stale filter
+          </Link>
+        </div>
+      ) : null}
+
+      {hasActiveFilters && !staleOnly ? (
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-2 text-sm text-zinc-700">
+          <span>Filters are synced to the URL — copy the address bar to share this view.</span>
+          <Link
+            href={clearFiltersHref}
+            className="shrink-0 font-medium text-violet-800 underline-offset-2 hover:underline"
+          >
+            Clear filters
           </Link>
         </div>
       ) : null}
 
       <p className="mb-2 text-xs text-zinc-500">
-        Showing {filtered.length} of {rows.length} loaded
+        {loading && rows.length === 0
+          ? "Loading…"
+          : `Showing ${filtered.length} of ${rows.length} loaded`}
       </p>
 
       <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
-        <table className="min-w-full text-left text-sm">
-          <thead className="border-b border-zinc-100 bg-zinc-50 text-xs font-medium uppercase text-zinc-500">
-            <tr>
-              <th className="px-4 py-2">Opportunity</th>
-              <th className="px-4 py-2">Account</th>
-              <th className="px-4 py-2">Stage</th>
-              <th className="px-4 py-2">%</th>
-              <th className="px-4 py-2">Close</th>
-              <th className="px-4 py-2">Next step</th>
-              <th className="px-4 py-2">Owner</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.length === 0 ? (
+        {loading && rows.length === 0 && !error ? (
+          <div className="px-4 py-10 text-center">
+            <div className="mx-auto mb-3 h-8 w-48 animate-pulse rounded bg-zinc-100" />
+            <div className="mx-auto h-4 w-64 animate-pulse rounded bg-zinc-50" />
+            <p className="mt-3 text-sm text-zinc-500">Loading opportunities…</p>
+          </div>
+        ) : error && rows.length === 0 ? null : (
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-zinc-100 bg-zinc-50 text-xs font-medium uppercase text-zinc-500">
               <tr>
-                <td colSpan={7} className="px-4 py-8 text-center text-zinc-500">
-                  No opportunities match.
-                </td>
+                <th className="px-4 py-2">Opportunity</th>
+                <th className="px-4 py-2">Account</th>
+                <th className="px-4 py-2">Stage</th>
+                <th className="px-4 py-2">%</th>
+                <th className="px-4 py-2">Close</th>
+                <th className="px-4 py-2">Next step</th>
+                <th className="px-4 py-2">Owner</th>
               </tr>
-            ) : (
-              filtered.map((row) => (
-                <tr key={row.id} className="border-b border-zinc-50 last:border-0">
-                  <td className="px-4 py-2">
-                    <Link
-                      href={`/crm/opportunities/${row.id}`}
-                      className="font-medium text-violet-700 hover:text-violet-900 hover:underline"
-                    >
-                      {row.name}
-                    </Link>
+            </thead>
+            <tbody>
+              {!error && rows.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-12 text-center">
+                    <p className="text-sm font-medium text-zinc-800">No opportunities in this workspace</p>
+                    <p className="mt-1 text-sm text-zinc-500">
+                      Create one from an account or check your CRM role scope.
+                    </p>
                   </td>
-                  <td className="px-4 py-2">
-                    <Link
-                      href={`/crm/accounts/${row.account.id}`}
-                      className="text-zinc-700 hover:text-violet-800 hover:underline"
-                    >
-                      {row.account.name}
-                    </Link>
-                  </td>
-                  <td className="max-w-[10rem] truncate px-4 py-2 text-zinc-600" title={row.stage}>
-                    {row.stage.replace(/_/g, " ")}
-                  </td>
-                  <td className="px-4 py-2 text-zinc-600">{row.probability}</td>
-                  <td className="px-4 py-2 text-xs text-zinc-500">
-                    {row.closeDate ? new Date(row.closeDate).toLocaleDateString() : "—"}
-                  </td>
-                  <td className="px-4 py-2 text-xs text-zinc-500">
-                    {row.nextStepDate
-                      ? new Date(row.nextStepDate).toLocaleDateString()
-                      : "—"}
-                  </td>
-                  <td className="px-4 py-2 text-zinc-600">{row.owner.name}</td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+              ) : null}
+              {rows.length > 0 && filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-12 text-center">
+                    <p className="text-sm font-medium text-zinc-800">No opportunities match</p>
+                    <p className="mt-1 text-sm text-zinc-500">
+                      Try widening stage, owner, or search — or{" "}
+                      <Link href={clearFiltersHref} className="font-medium text-violet-800 hover:underline">
+                        clear filters
+                      </Link>
+                      .
+                    </p>
+                  </td>
+                </tr>
+              ) : null}
+              {filtered.length > 0
+                ? filtered.map((row) => (
+                    <tr key={row.id} className="border-b border-zinc-50 last:border-0">
+                      <td className="px-4 py-2">
+                        <Link
+                          href={`/crm/opportunities/${row.id}`}
+                          className="font-medium text-violet-700 hover:text-violet-900 hover:underline"
+                        >
+                          {row.name}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2">
+                        <Link
+                          href={`/crm/accounts/${row.account.id}`}
+                          className="text-zinc-700 hover:text-violet-800 hover:underline"
+                        >
+                          {row.account.name}
+                        </Link>
+                      </td>
+                      <td className="max-w-[10rem] truncate px-4 py-2 text-zinc-600" title={row.stage}>
+                        {row.stage.replace(/_/g, " ")}
+                      </td>
+                      <td className="px-4 py-2 text-zinc-600">{row.probability}</td>
+                      <td className="px-4 py-2 text-xs text-zinc-500">
+                        {row.closeDate ? new Date(row.closeDate).toLocaleDateString() : "—"}
+                      </td>
+                      <td className="px-4 py-2 text-xs text-zinc-500">
+                        {row.nextStepDate
+                          ? new Date(row.nextStepDate).toLocaleDateString()
+                          : "—"}
+                      </td>
+                      <td className="px-4 py-2 text-zinc-600">{row.owner.name}</td>
+                    </tr>
+                  ))
+                : null}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/src/components/crm-quote-detail.tsx
+++ b/src/components/crm-quote-detail.tsx
@@ -139,8 +139,18 @@ export function CrmQuoteDetail({
   if (error && !quote) {
     return (
       <div className="mx-auto max-w-2xl px-6 py-16">
-        <p className="text-sm text-red-700">{error}</p>
-        <Link href="/crm/quotes" className="mt-4 inline-block text-sm text-violet-700">
+        <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-4 shadow-sm" role="alert">
+          <p className="text-sm font-medium text-red-900">Could not load quote</p>
+          <p className="mt-1 text-sm text-red-800">{error}</p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="mt-3 rounded-lg border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-900 hover:bg-red-100"
+          >
+            Try again
+          </button>
+        </div>
+        <Link href="/crm/quotes" className="mt-6 inline-block text-sm font-medium text-violet-700 hover:underline">
           ← Quotes
         </Link>
       </div>
@@ -148,7 +158,13 @@ export function CrmQuoteDetail({
   }
 
   if (!quote) {
-    return <div className="px-6 py-16 text-sm text-zinc-500">Loading…</div>;
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-16 text-center">
+        <div className="mx-auto mb-3 h-8 w-56 animate-pulse rounded-lg bg-zinc-100" />
+        <div className="mx-auto h-4 w-72 animate-pulse rounded bg-zinc-50" />
+        <p className="mt-4 text-sm text-zinc-500">Loading quote…</p>
+      </div>
+    );
   }
 
   const canPatch = canEditAll || quote.ownerUserId === actorUserId;
@@ -186,7 +202,7 @@ export function CrmQuoteDetail({
       </p>
 
       {error ? (
-        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-900">
+        <div className="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900 shadow-sm">
           {error}
         </div>
       ) : null}
@@ -240,8 +256,15 @@ export function CrmQuoteDetail({
       )}
 
       <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-zinc-900">Line items</h2>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-zinc-900">Line items</h2>
+            <p className="mt-1 text-xs text-zinc-500">
+              Loaded with the quote from{" "}
+              <code className="rounded bg-zinc-100 px-1 py-0.5 text-[11px]">GET /api/crm/quotes/[id]</code>{" "}
+              (includes lines).
+            </p>
+          </div>
           <p className="text-sm text-zinc-600">
             Subtotal:{" "}
             <span className="font-medium text-zinc-900">
@@ -249,64 +272,117 @@ export function CrmQuoteDetail({
             </span>
           </p>
         </div>
-        {canPatch ? (
-          <form onSubmit={addLine} className="mt-4 grid gap-2 border-b border-zinc-100 pb-4 sm:grid-cols-4">
-            <input
-              placeholder="Description"
-              value={desc}
-              onChange={(e) => setDesc(e.target.value)}
-              className="rounded-lg border border-zinc-200 px-3 py-2 text-sm sm:col-span-2"
-              disabled={busy}
-            />
-            <input
-              placeholder="Qty"
-              value={qty}
-              onChange={(e) => setQty(e.target.value)}
-              className="rounded-lg border border-zinc-200 px-3 py-2 text-sm"
-              disabled={busy}
-            />
-            <input
-              placeholder="Unit price"
-              value={price}
-              onChange={(e) => setPrice(e.target.value)}
-              className="rounded-lg border border-zinc-200 px-3 py-2 text-sm"
-              disabled={busy}
-            />
-            <button
-              type="submit"
-              disabled={busy || !desc.trim() || !price.trim()}
-              className="rounded-lg border border-violet-200 bg-violet-50 px-3 py-2 text-sm font-medium text-violet-900 sm:col-span-4"
-            >
-              Add line
-            </button>
-          </form>
-        ) : null}
-        <ul className="mt-4 divide-y divide-zinc-100 text-sm">
-          {quote.lines.length === 0 ? (
-            <li className="py-4 text-zinc-500">No lines yet.</li>
-          ) : (
-            quote.lines.map((l) => (
-              <li key={l.id} className="flex flex-wrap items-center justify-between gap-2 py-3">
-                <div>
-                  <div className="font-medium text-zinc-900">{l.description}</div>
-                  <div className="text-xs text-zinc-500">
-                    {l.quantity} × {l.unitPrice} = {l.extendedAmount ?? "—"}
-                  </div>
-                </div>
-                {canPatch ? (
-                  <button
-                    type="button"
-                    disabled={busy}
-                    onClick={() => void removeLine(l.id)}
-                    className="text-xs font-medium text-red-700 hover:underline disabled:opacity-50"
+
+        <div className="mt-4 overflow-x-auto rounded-lg border border-zinc-100">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-zinc-100 bg-zinc-50 text-xs font-medium uppercase text-zinc-500">
+              <tr>
+                <th className="px-3 py-2">Description</th>
+                <th className="px-3 py-2 text-right">Qty</th>
+                <th className="px-3 py-2 text-right">Unit price</th>
+                <th className="px-3 py-2 text-right">Line total</th>
+                {canPatch ? <th className="px-3 py-2 text-right">Actions</th> : null}
+              </tr>
+            </thead>
+            <tbody>
+              {quote.lines.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={canPatch ? 5 : 4}
+                    className="px-3 py-10 text-center text-sm text-zinc-500"
                   >
-                    Remove
-                  </button>
-                ) : null}
-              </li>
-            ))
-          )}
-        </ul>
+                    No line items on this quote yet.
+                  </td>
+                </tr>
+              ) : (
+                [...quote.lines]
+                  .sort((a, b) => a.sortOrder - b.sortOrder)
+                  .map((l) => (
+                    <tr key={l.id} className="border-b border-zinc-50 last:border-0">
+                      <td className="max-w-xs px-3 py-2 font-medium text-zinc-900">{l.description}</td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums text-zinc-700">
+                        {l.quantity}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums text-zinc-700">
+                        {l.unitPrice} {quote.currency}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums text-zinc-900">
+                        {l.extendedAmount != null ? `${l.extendedAmount} ${quote.currency}` : "—"}
+                      </td>
+                      {canPatch ? (
+                        <td className="px-3 py-2 text-right">
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => void removeLine(l.id)}
+                            className="text-xs font-medium text-red-700 hover:underline disabled:opacity-50"
+                          >
+                            Remove
+                          </button>
+                        </td>
+                      ) : null}
+                    </tr>
+                  ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {canPatch ? (
+          <div id="crm-quote-add-line" className="mt-6 border-t border-zinc-100 pt-5">
+            <h3 className="text-sm font-semibold text-zinc-900">Add a line</h3>
+            <p className="mt-1 text-xs text-zinc-500">
+              Inline add uses{" "}
+              <code className="rounded bg-zinc-100 px-1 py-0.5 text-[11px]">POST /api/crm/quotes/[id]/lines</code>
+              . Deep link:{" "}
+              <Link
+                href={`/crm/quotes/${quoteId}#crm-quote-add-line`}
+                className="font-medium text-violet-800 hover:underline"
+              >
+                #crm-quote-add-line
+              </Link>
+              .
+            </p>
+            <form onSubmit={addLine} className="mt-4 grid gap-2 sm:grid-cols-4">
+              <input
+                placeholder="Description"
+                value={desc}
+                onChange={(e) => setDesc(e.target.value)}
+                className="rounded-lg border border-zinc-200 px-3 py-2 text-sm sm:col-span-2"
+                disabled={busy}
+              />
+              <input
+                placeholder="Qty"
+                value={qty}
+                onChange={(e) => setQty(e.target.value)}
+                className="rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                disabled={busy}
+              />
+              <input
+                placeholder="Unit price"
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+                className="rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                disabled={busy}
+              />
+              <button
+                type="submit"
+                disabled={busy || !desc.trim() || !price.trim()}
+                className="rounded-lg border border-violet-200 bg-violet-50 px-3 py-2 text-sm font-medium text-violet-900 sm:col-span-4"
+              >
+                Add line
+              </button>
+            </form>
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-zinc-600">
+            Adding or editing lines requires quote owner (or CRM edit-all) access. Use{" "}
+            <Link href="/settings/demo" className="font-medium text-violet-800 hover:underline">
+              Settings → Demo session
+            </Link>{" "}
+            to act as the owner, or ask an admin for the org CRM edit grant.
+          </p>
+        )}
       </section>
     </div>
   );

--- a/src/lib/crm/opportunities-list-query.test.ts
+++ b/src/lib/crm/opportunities-list-query.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOpportunitiesListSearch,
+  parseOpportunitiesListQuery,
+} from "./opportunities-list-query";
+
+describe("parseOpportunitiesListQuery", () => {
+  it("reads stage, owner, q and stale", () => {
+    const sp = new URLSearchParams("stage=QUALIFIED&owner=u1&q=acme&stale=1");
+    expect(parseOpportunitiesListQuery(sp)).toEqual({
+      stage: "QUALIFIED",
+      owner: "u1",
+      q: "acme",
+      stale: true,
+    });
+  });
+
+  it("trims values and defaults stale", () => {
+    const sp = new URLSearchParams("stage=%20DISCOVERY%20&owner=&q=%20");
+    expect(parseOpportunitiesListQuery(sp)).toEqual({
+      stage: "DISCOVERY",
+      owner: "",
+      q: "",
+      stale: false,
+    });
+  });
+});
+
+describe("buildOpportunitiesListSearch", () => {
+  it("sets non-empty keys and removes empty ones", () => {
+    const base = new URLSearchParams("stale=1&foo=bar");
+    const out = buildOpportunitiesListSearch(base, { stage: "LOST", owner: "", q: "x" });
+    const next = new URLSearchParams(out);
+    expect(next.get("stale")).toBe("1");
+    expect(next.get("foo")).toBe("bar");
+    expect(next.get("stage")).toBe("LOST");
+    expect(next.has("owner")).toBe(false);
+    expect(next.get("q")).toBe("x");
+  });
+
+  it("clears q when patched to whitespace", () => {
+    const base = new URLSearchParams("q=old");
+    const out = buildOpportunitiesListSearch(base, { q: "   " });
+    expect(new URLSearchParams(out).has("q")).toBe(false);
+  });
+});

--- a/src/lib/crm/opportunities-list-query.ts
+++ b/src/lib/crm/opportunities-list-query.ts
@@ -1,0 +1,40 @@
+/** Pure helpers for CRM opportunities list URL query (?stage=&owner=&q=&stale=). */
+
+export type OpportunitiesListQuery = {
+  stage: string;
+  owner: string;
+  q: string;
+  stale: boolean;
+};
+
+export function parseOpportunitiesListQuery(searchParams: URLSearchParams): OpportunitiesListQuery {
+  return {
+    stage: (searchParams.get("stage") ?? "").trim(),
+    owner: (searchParams.get("owner") ?? "").trim(),
+    q: (searchParams.get("q") ?? "").trim(),
+    stale: searchParams.get("stale") === "1",
+  };
+}
+
+/**
+ * Merge filter patch into current search string. Omits empty filter keys; preserves unrelated keys (e.g. stale=1).
+ */
+export function buildOpportunitiesListSearch(
+  current: URLSearchParams,
+  patch: Partial<{ stage: string; owner: string; q: string }>,
+): string {
+  const next = new URLSearchParams(current.toString());
+
+  const apply = (key: "stage" | "owner" | "q", value: string | undefined) => {
+    if (value === undefined) return;
+    const t = value.trim();
+    if (t) next.set(key, t);
+    else next.delete(key);
+  };
+
+  if (patch.stage !== undefined) apply("stage", patch.stage);
+  if (patch.owner !== undefined) apply("owner", patch.owner);
+  if (patch.q !== undefined) apply("q", patch.q);
+
+  return next.toString();
+}


### PR DESCRIPTION
Implements [GitHub issue #10](https://github.com/lasealco/po-management/issues/10) (no comments on the issue).

### Opportunities list
- **Stage**, **owner** (user id from loaded rows), and **search** (`q`) filters with **`router.replace`** URL sync: `?stage=&owner=&q=`; existing **`stale=1`** is preserved when changing filters.
- **Loading** skeleton on first fetch, **error** panel with retry, distinct **empty** vs **no filter matches** copy; filter hint + clear links aligned with existing CRM panels.

### Quote detail
- **Read-only line items table** (description, qty, unit price, line total + currency) sourced from **`GET /api/crm/quotes/[id]`** (Prisma-included `lines`), same as before — no duplicated line-fetch logic.
- **Add line**: editors keep the inline form under **`#crm-quote-add-line`** with a deep link in copy; read-only users see guidance + **Settings → Demo session** (no fake separate editor route).

### Tests
- **`src/lib/crm/opportunities-list-query.test.ts`** — Vitest for URL parse/build helpers.

### Green gate (on this branch)
`npm run lint && npx tsc --noEmit && npm run test`

### PR note (add-line)
Full inline add remains on this page for users who can patch the quote; deep link **`/crm/quotes/<id>#crm-quote-add-line`** documents the “edit surface” for collaborators.

**Do not merge** per issue instructions — review and merge when ready.

Made with [Cursor](https://cursor.com)