### PR TITLE
feat(tariff): issue #12 meeting batch — import tests and UI

### DIFF
--- a/src/app/api/tariffs/import-batches/_lib/promote-import-body.test.ts
+++ b/src/app/api/tariffs/import-batches/_lib/promote-import-body.test.ts
@@ -24,4 +24,22 @@ describe("parsePromoteImportRequestBody", () => {
       error: "contractHeaderId is required.",
     });
   });
+
+  it("rejects whitespace-only contractHeaderId", () => {
+    expect(parsePromoteImportRequestBody({ contractHeaderId: "   " })).toEqual({
+      ok: false,
+      error: "contractHeaderId is required.",
+    });
+    expect(parsePromoteImportRequestBody({ contractHeaderId: "\t\n" })).toEqual({
+      ok: false,
+      error: "contractHeaderId is required.",
+    });
+  });
+
+  it("treats array bodies like empty objects (no string id)", () => {
+    expect(parsePromoteImportRequestBody([])).toEqual({
+      ok: false,
+      error: "contractHeaderId is required.",
+    });
+  });
 });

--- a/src/app/tariffs/import/[batchId]/page.tsx
+++ b/src/app/tariffs/import/[batchId]/page.tsx
@@ -78,7 +78,8 @@ export default async function TariffImportBatchDetailPage({ params }: { params: 
       <section className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">Import batch</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">Workflow · Step 2</p>
+            <p className="mt-1 text-xs font-medium uppercase tracking-wide text-zinc-400">Import batch</p>
             <h1 className="mt-2 text-2xl font-semibold text-zinc-900">{batch.uploadedFilename ?? "Untitled file"}</h1>
             <div className="mt-3 flex flex-wrap gap-2">
               <TariffImportParseBadge status={batch.parseStatus} />

--- a/src/components/tariffs/tariff-import-promote-panel.tsx
+++ b/src/components/tariffs/tariff-import-promote-panel.tsx
@@ -35,7 +35,9 @@ export function TariffImportPromotePanel({
       });
       const data = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) {
-        setError(data.error ?? "Fixture failed.");
+        const fromServer = typeof data.error === "string" ? data.error.trim() : "";
+        const detail = fromServer || "The fixture request was rejected.";
+        setError(`${detail} (HTTP ${res.status})");
         return;
       }
       router.refresh();
@@ -65,7 +67,9 @@ export function TariffImportPromotePanel({
         chargeLineCount?: number;
       };
       if (!res.ok) {
-        setError(data.error ?? "Promote failed.");
+        const fromServer = typeof data.error === "string" ? data.error.trim() : "";
+        const detail = fromServer || "Promote was rejected.";
+        setError(`${detail} (HTTP ${res.status})");
         return;
       }
       router.refresh();
@@ -88,7 +92,17 @@ export function TariffImportPromotePanel({
         a new <strong>draft</strong> version).
       </p>
 
-      {error ? <p className="mt-2 text-sm text-red-800">{error}</p> : null}
+      {error ? (
+        <div
+          className="mt-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          role="alert"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <p className="font-semibold text-red-900">Action blocked</p>
+          <p className="mt-1">{error}</p>
+        </div>
+      ) : null}
 
       <div className="mt-3 flex flex-wrap gap-2">
         <button
@@ -123,7 +137,7 @@ export function TariffImportPromotePanel({
           type="button"
           disabled={pendingPromote || !headerId}
           onClick={() => void promote()}
-          className="rounded-xl bg-emerald-700 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:brightness-95 disabled:opacity-50"
+          className="rounded-xl bg-[var(--arscmp-primary)] px-4 py-2 text-sm font-semibold text-white shadow-sm hover:brightness-95 disabled:opacity-50"
         >
           {pendingPromote ? "Promoting…" : "Promote → new draft version"}
         </button>

--- a/src/components/tariffs/tariff-import-promote-panel.tsx
+++ b/src/components/tariffs/tariff-import-promote-panel.tsx
@@ -37,7 +37,7 @@ export function TariffImportPromotePanel({
       if (!res.ok) {
         const fromServer = typeof data.error === "string" ? data.error.trim() : "";
         const detail = fromServer || "The fixture request was rejected.";
-        setError(`${detail} (HTTP ${res.status})");
+        setError(`${detail} (HTTP ${res.status})`);
         return;
       }
       router.refresh();
@@ -69,7 +69,7 @@ export function TariffImportPromotePanel({
       if (!res.ok) {
         const fromServer = typeof data.error === "string" ? data.error.trim() : "";
         const detail = fromServer || "Promote was rejected.";
-        setError(`${detail} (HTTP ${res.status})");
+        setError(`${detail} (HTTP ${res.status})`);
         return;
       }
       router.refresh();

--- a/src/components/tariffs/tariff-import-upload-form-client.tsx
+++ b/src/components/tariffs/tariff-import-upload-form-client.tsx
@@ -38,7 +38,9 @@ export function TariffImportUploadFormClient({
       const res = await fetch("/api/tariffs/import-batches", { method: "POST", body: up });
       const data = (await res.json().catch(() => ({}))) as { error?: string; batch?: { id: string } };
       if (!res.ok) {
-        setError(data.error ?? "Upload failed.");
+        const fromServer = typeof data.error === "string" ? data.error.trim() : "";
+        const detail = fromServer || "The server did not accept this upload.";
+        setError(`${detail} If this keeps happening, note HTTP ${res.status} for support.");
         return;
       }
       if (data.batch?.id) {
@@ -55,9 +57,15 @@ export function TariffImportUploadFormClient({
   return (
     <form className="space-y-6" onSubmit={(ev) => void onSubmit(ev)}>
       {error ? (
-        <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" role="alert">
-          {error}
-        </p>
+        <div
+          className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          role="alert"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <p className="font-semibold text-red-900">Upload could not complete</p>
+          <p className="mt-1 text-red-800">{error}</p>
+        </div>
       ) : null}
 
       <label className="block text-sm">

--- a/src/components/tariffs/tariff-import-upload-form-client.tsx
+++ b/src/components/tariffs/tariff-import-upload-form-client.tsx
@@ -40,7 +40,7 @@ export function TariffImportUploadFormClient({
       if (!res.ok) {
         const fromServer = typeof data.error === "string" ? data.error.trim() : "";
         const detail = fromServer || "The server did not accept this upload.";
-        setError(`${detail} If this keeps happening, note HTTP ${res.status} for support.");
+        setError(`${detail} If this keeps happening, note HTTP ${res.status} for support.`);
         return;
       }
       if (data.batch?.id) {

--- a/src/lib/tariff/import-pipeline.test.ts
+++ b/src/lib/tariff/import-pipeline.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { TARIFF_IMPORT_STAGING_ROW_TYPE_SET, TARIFF_IMPORT_STAGING_ROW_TYPES } from "@/lib/tariff/import-pipeline";
+import {
+  TARIFF_IMPORT_NORMALIZED_PAYLOAD_KEYS,
+  TARIFF_IMPORT_STAGING_ROW_TYPE_SET,
+  TARIFF_IMPORT_STAGING_ROW_TYPES,
+} from "@/lib/tariff/import-pipeline";
 
 describe("import-pipeline staging row types", () => {
   it("includes documented row types", () => {
@@ -11,5 +15,17 @@ describe("import-pipeline staging row types", () => {
   it("exposes a set for validation", () => {
     expect(TARIFF_IMPORT_STAGING_ROW_TYPE_SET.has("RAW_ROW")).toBe(true);
     expect(TARIFF_IMPORT_STAGING_ROW_TYPE_SET.has("UNKNOWN")).toBe(false);
+  });
+});
+
+describe("import-pipeline normalized payload keys", () => {
+  it("maps stable field names to matching JSON keys", () => {
+    expect(TARIFF_IMPORT_NORMALIZED_PAYLOAD_KEYS.contractNumber).toBe("contractNumber");
+    expect(TARIFF_IMPORT_NORMALIZED_PAYLOAD_KEYS.amount).toBe("amount");
+  });
+
+  it("uses unique string values for every normalized field", () => {
+    const vals = Object.values(TARIFF_IMPORT_NORMALIZED_PAYLOAD_KEYS);
+    expect(new Set(vals).size).toBe(vals.length);
   });
 });


### PR DESCRIPTION
Closes #12

## What changed
- **Vitest:** `import-pipeline.test.ts` (normalized payload key invariants) and `promote-import-body.test.ts` (whitespace-only `contractHeaderId`, empty JSON body).
- **Import UI:** Clearer server error handling with HTTP status on upload and promote flows; accessible error regions (`role="alert"`, live region); primary **Promote** CTA uses `var(--arscmp-primary)`; batch detail page adds workflow eyebrow (Step 2) aligned with Step 1 on new upload.
- **Follow-up:** `fix(tariff): close import error template literals` — corrects mismatched quotes on `setError` template strings so ESLint/TypeScript accept the UI changes.

## Test file choice (issue checklist)
- **`tariff-workbench-urls`** already has solid unit coverage.
- **`geography-catalog`** is Prisma-backed; heavier to unit-test in this batch without DB fixtures.
- **`import-pipeline`** and **`promote-import-body`** are thin, high-churn validation paths worth locking in.

## Quality gate
`npm run verify:tariff-engine` passes on this branch.

**Note:** Do not merge from this description; merge when you are ready after review.

Made with [Cursor](https://cursor.com)