### PR TITLE
feat(apihub): P0 docs, /apihub shell, and health API (#16)

### DIFF
--- a/docs/apihub/GAP_MAP.md
+++ b/docs/apihub/GAP_MAP.md
@@ -2,14 +2,14 @@
 
 **Legend:** ✅ shipped · 🟡 partial / stub · ❌ not started
 
-**Last updated:** (set when the first API hub PR merges)
+**Last updated:** 2026-04-20 (P0 shell + health stub)
 
 | Area | Repo reality | Notes |
 |------|--------------|--------|
-| Docs home | 🟡 `docs/apihub/README.md`, specs | This folder |
+| Docs home | ✅ `docs/apihub/README.md`, specs | Cross-linked README + spec |
 | Ingestion spec | 🟡 `integrations-ai-assisted-ingestion.md` | Draft; evolves with P0–P4 |
-| App route `/apihub` | ❌ | P0 shell target |
-| Health / discovery API | ❌ | e.g. `GET /api/apihub/health` |
+| App route `/apihub` | ✅ `src/app/apihub/**` | Read-only shell; demo session required |
+| Health / discovery API | ✅ `GET /api/apihub/health` | `{ ok, service, phase }`; no secrets |
 | Prisma: connector / template / batch | ❌ | P1 |
 | AI job + mapping editor | ❌ | P2 |
 | Deterministic apply + idempotent API | ❌ | P3 |

--- a/docs/apihub/README.md
+++ b/docs/apihub/README.md
@@ -2,11 +2,20 @@
 
 This folder is the **documentation home** for **integration / ingestion APIs and UX**: how external data and files enter the platform, how operators confirm mappings, and how runs are **repeatable** and **auditable**.
 
+**Browse on GitHub (public):** [`lasealco/po-management` → `docs/apihub/`](https://github.com/lasealco/po-management/tree/main/docs/apihub)
+
 ## Specs (markdown)
 
 | Document | Purpose |
 |----------|---------|
 | [integrations-ai-assisted-ingestion.md](./integrations-ai-assisted-ingestion.md) | End-to-end product + technical spec: AI-assisted ingestion, templates, API + file parity, guardrails, phased delivery |
+
+**Gap map (spec ↔ code):** [GAP_MAP.md](./GAP_MAP.md)
+
+## In-app entry (P0)
+
+- Authenticated demo session: **`/apihub`** (read-only shell; see [GAP_MAP](./GAP_MAP.md)).
+- **Health stub:** `GET /api/apihub/health` — JSON `{ ok, service, phase }` for discovery and deploy checks.
 
 ## Related material elsewhere
 
@@ -16,4 +25,4 @@ This folder is the **documentation home** for **integration / ingestion APIs and
 ## Naming
 
 - **`docs/apihub/`** = docs and product language for this initiative.
-- **Application routes** may use `/apihub` (or a final product name decided in spec); keep code and docs cross-linked from `GAP_MAP.md` once it exists.
+- **Application routes** use `/apihub` for the P0 shell; final product naming is tracked in the spec open decisions. Keep this README, [GAP_MAP](./GAP_MAP.md), and the [phased delivery table](./integrations-ai-assisted-ingestion.md#8-phased-delivery-proposal) aligned when shipping phases.

--- a/docs/apihub/integrations-ai-assisted-ingestion.md
+++ b/docs/apihub/integrations-ai-assisted-ingestion.md
@@ -1,6 +1,6 @@
 # AI-assisted ingestion — integration / API hub spec (v1 draft)
 
-**Status:** Draft for engineering + product alignment. **Source docs home:** [`README.md`](./README.md).
+**Status:** Draft for engineering + product alignment. **Source docs home:** [`README.md`](./README.md). **Docs on GitHub (public tree):** [`docs/apihub/`](https://github.com/lasealco/po-management/tree/main/docs/apihub).
 
 ---
 
@@ -94,7 +94,7 @@ Exact Prisma names and relations are **P1+**; this table is the conceptual contr
 
 | Phase | Scope (summary) |
 |-------|------------------|
-| **P0** | Docs home (`docs/apihub/`), **GAP_MAP**, read-only **app shell** (`/apihub`), health API stub, cross-links from integration-hub todos; no Prisma migrations unless explicitly approved. |
+| **P0** | Docs home (`docs/apihub/`), **GAP_MAP**, read-only **app shell** ([`/apihub`](https://github.com/lasealco/po-management/tree/main/src/app/apihub)), [`GET /api/apihub/health`](https://github.com/lasealco/po-management/tree/main/src/app/api/apihub/health), cross-links from integration-hub todos; no Prisma migrations unless explicitly approved. |
 | **P1** | Prisma models for connector + template + batch + staging (minimal); CRUD API stubs; empty list UIs. |
 | **P2** | Async “analysis job” pipeline + mapping editor UI + staging preview. |
 | **P3** | Deterministic apply to production paths (per scenario); idempotent API; wire to CT/PO/SO as agreed. |
@@ -115,3 +115,4 @@ Exact Prisma names and relations are **P1+**; this table is the conceptual contr
 
 - Control Tower inbound: `docs/controltower/GAP_MAP.md` (R4).
 - Engineering agent list: `docs/engineering/agent-todos/integration-hub.md`.
+- **P0 implementation pointers:** app shell `src/app/apihub/`, health route `src/app/api/apihub/health/route.ts`, shared constants `src/lib/apihub/`.

--- a/docs/engineering/agent-todos/integration-hub.md
+++ b/docs/engineering/agent-todos/integration-hub.md
@@ -1,19 +1,25 @@
 # Integration hub / API hub — agent todo list (greenfield)
 
-**GitHub label:** `module:integration-hub`  
-**Live spec + docs:** **[`docs/apihub/README.md`](../../apihub/README.md)** — ingestion / integration API hub; full draft: [`integrations-ai-assisted-ingestion.md`](../../apihub/integrations-ai-assisted-ingestion.md).  
-**Gap map:** [`docs/apihub/GAP_MAP.md`](../../apihub/GAP_MAP.md).
+**GitHub label:** `module:integration-hub`
 
-**Suggested allowed paths (P0):** `docs/apihub/**`, `docs/engineering/agent-todos/integration-hub.md`, `src/app/apihub/**`, `src/app/api/apihub/**`, optional tiny `src/lib/apihub/**`
+## Live spec home (use this instead of one-off “product one-pager” todos)
+
+- **Documentation home:** [`docs/apihub/README.md`](../../apihub/README.md) — ingestion / integration API hub overview, GitHub links, in-app entry.
+- **Full draft spec:** [`docs/apihub/integrations-ai-assisted-ingestion.md`](../../apihub/integrations-ai-assisted-ingestion.md) — product + technical contract (supersedes informal one-pager requests; iterate here and in PRs).
+- **Gap map:** [`docs/apihub/GAP_MAP.md`](../../apihub/GAP_MAP.md) — what is shipped vs stub vs not started.
+
+**P0 (meeting batch):** docs polish + read-only **`/apihub`** shell + **`GET /api/apihub/health`** — no Prisma / migrations unless explicitly approved. **P1+:** connector registry, jobs, mapping editor, deterministic apply — see spec phased delivery §8.
+
+**Suggested allowed paths (P0 PRs):** `docs/apihub/**`, `docs/engineering/agent-todos/integration-hub.md`, `src/app/apihub/**`, `src/app/api/apihub/**`, optional tiny `src/lib/apihub/**`
 
 ---
 
 ## Phase 0 — skeleton (safe, no backend contract yet)
 
 - [x] **Product / technical spec** — [`docs/apihub/integrations-ai-assisted-ingestion.md`](../../apihub/integrations-ai-assisted-ingestion.md) (v1 draft; iterate in PRs).
-- [ ] **Route shell** — `/apihub` landing + step placeholders — GitHub [#16](https://github.com/lasealco/po-management/issues/16) (meeting batch P0).
-- [ ] **Health API** — `GET /api/apihub/health` stub (same issue).
-- [ ] **Nav / command palette** — optional single entry (minimal diff; see #16).
+- [x] **Route shell** — `/apihub` landing + step placeholders — GitHub [#16](https://github.com/lasealco/po-management/issues/16) (meeting batch P0).
+- [x] **Health API** — `GET /api/apihub/health` stub (same issue).
+- [x] **Nav / command palette** — command palette entry → `/apihub` for signed-in demo users (minimal; see #16).
 
 ---
 
@@ -27,4 +33,4 @@
 
 ## Hygiene
 
-- [ ] Keep [`docs/apihub/GAP_MAP.md`](../../apihub/GAP_MAP.md) current when merging API hub PRs.
+- [x] Keep [`docs/apihub/GAP_MAP.md`](../../apihub/GAP_MAP.md) current when merging API hub PRs (P0 row updated 2026-04-20).

--- a/src/app/api/apihub/health/route.ts
+++ b/src/app/api/apihub/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+import { getApiHubHealthJson } from "@/lib/apihub/health-body";
+
+export function GET() {
+  return NextResponse.json(getApiHubHealthJson());
+}

--- a/src/app/apihub/apihub-gate.tsx
+++ b/src/app/apihub/apihub-gate.tsx
@@ -1,0 +1,17 @@
+import { AccessDenied } from "@/components/access-denied";
+import { getViewerGrantSet } from "@/lib/authz";
+
+export async function ApihubGate({ children }: { children: React.ReactNode }) {
+  const access = await getViewerGrantSet();
+  if (!access?.user) {
+    return (
+      <div className="px-6 py-16">
+        <AccessDenied
+          title="API hub"
+          message="Choose an active demo user: open Settings → Demo session (/settings/demo)."
+        />
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/src/app/apihub/apihub-header.tsx
+++ b/src/app/apihub/apihub-header.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export function ApihubHeader() {
+  return (
+    <header className="border-b border-zinc-200 bg-white">
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">Module</p>
+          <h1 className="text-base font-semibold text-zinc-900">API hub</h1>
+        </div>
+        <nav className="flex flex-wrap items-center justify-end gap-3 text-sm">
+          <Link href="/settings/demo" className="font-medium text-zinc-600 hover:text-zinc-900">
+            Demo session
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/app/apihub/layout.tsx
+++ b/src/app/apihub/layout.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+
+import { ApihubGate } from "./apihub-gate";
+import { ApihubHeader } from "./apihub-header";
+
+export default function ApihubLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ApihubGate>
+      <div className="min-h-screen bg-zinc-50">
+        <Suspense fallback={<div className="h-10 border-b border-zinc-200 bg-white" />}>
+          <ApihubHeader />
+        </Suspense>
+        {children}
+      </div>
+    </ApihubGate>
+  );
+}

--- a/src/app/apihub/page.tsx
+++ b/src/app/apihub/page.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_DOCS_APIHUB_TREE =
+  "https://github.com/lasealco/po-management/tree/main/docs/apihub";
+const GITHUB_SPEC_BLOB =
+  "https://github.com/lasealco/po-management/blob/main/docs/apihub/integrations-ai-assisted-ingestion.md";
+
+const STEP_PLACEHOLDERS = [
+  {
+    n: 1,
+    title: "Intent",
+    body: "Pick scenario and target (for example, new shipments from a partner file or API shape).",
+  },
+  {
+    n: 2,
+    title: "Uploads + optional docs",
+    body: "Bring sample files, example API JSON, and optional reference documents — not as a secret channel.",
+  },
+  {
+    n: 3,
+    title: "AI analysis job",
+    body: "Async job proposes structured mappings under guardrails; operators stay in control.",
+  },
+  {
+    n: 4,
+    title: "Mapping editor",
+    body: "Confirm source paths or columns → canonical fields, transforms, and required vs optional rules.",
+  },
+  {
+    n: 5,
+    title: "Validate + real UI preview",
+    body: "Dry-run against staging and open real app surfaces (read-only or flagged preview) where possible.",
+  },
+] as const;
+
+export default function ApihubHomePage() {
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <section className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">Workflow</p>
+        <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-zinc-900">Integration and ingestion hub</h2>
+            <p className="mt-2 max-w-2xl text-sm text-zinc-600">
+              Single place for AI-assisted mapping proposals, human confirmation, and repeatable runs across file
+              upload and server-to-server APIs. This page is a{" "}
+              <span className="font-medium text-zinc-800">Phase P0</span> shell: documentation and UX scaffolding only
+              — no connector database or live ingestion yet.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:items-end">
+            <a
+              href={GITHUB_DOCS_APIHUB_TREE}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center justify-center rounded-xl bg-[var(--arscmp-primary)] px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:brightness-95"
+            >
+              View docs on GitHub
+            </a>
+            <a
+              href={GITHUB_SPEC_BLOB}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm font-medium text-[var(--arscmp-primary)] hover:underline"
+            >
+              Open full spec (markdown)
+            </a>
+          </div>
+        </div>
+
+        <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {STEP_PLACEHOLDERS.map((step) => (
+            <div
+              key={step.n}
+              className="rounded-xl border border-zinc-200 bg-zinc-50/80 p-4 shadow-sm"
+            >
+              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Step {step.n} / 5</p>
+              <p className="mt-2 text-sm font-semibold text-zinc-900">{step.title}</p>
+              <p className="mt-2 text-xs leading-relaxed text-zinc-600">{step.body}</p>
+              <p className="mt-3 text-[11px] font-medium text-zinc-500">Placeholder — P1+</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+          <span className="font-medium text-zinc-800">Health:</span>{" "}
+          <code className="rounded bg-white px-1.5 py-0.5 font-mono text-xs text-zinc-800">GET /api/apihub/health</code>{" "}
+          returns <code className="rounded bg-white px-1.5 py-0.5 font-mono text-xs">ok</code>,{" "}
+          <code className="rounded bg-white px-1.5 py-0.5 font-mono text-xs">service</code>, and{" "}
+          <code className="rounded bg-white px-1.5 py-0.5 font-mono text-xs">phase</code> (no auth, no secrets).{" "}
+          <Link href="/api/apihub/health" className="font-medium text-[var(--arscmp-primary)] hover:underline">
+            Try it
+          </Link>
+          .
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,6 +68,7 @@ export default async function RootLayout({
           viewerHas(access.grantSet, "org.invoice_audit", "view")),
     ),
     invoiceAudit: Boolean(access?.user && viewerHas(access.grantSet, "org.invoice_audit", "view")),
+    apihub: Boolean(access?.user),
   };
 
   return (

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -35,6 +35,7 @@ export type CommandPaletteGrants = {
   rfq: boolean;
   pricingSnapshots: boolean;
   invoiceAudit: boolean;
+  apihub: boolean;
 };
 
 type CommandItem = {
@@ -75,6 +76,16 @@ export function CommandPalette({ grants }: { grants: CommandPaletteGrants }) {
         openHelp();
       },
     });
+
+    if (grants.apihub) {
+      list.push({
+        id: "apihub",
+        label: "API hub",
+        hint: "Integration and ingestion hub (P0 shell)",
+        searchText: "api hub integration ingestion connector webhook ingest",
+        action: go("/apihub"),
+      });
+    }
 
     list.push(
       {

--- a/src/lib/apihub/constants.ts
+++ b/src/lib/apihub/constants.ts
@@ -1,0 +1,5 @@
+/** Stable service id for health payloads and logging. */
+export const APIHUB_SERVICE = "apihub" as const;
+
+/** Current shipped phase label (P0 = docs + shell + health stub only). */
+export const APIHUB_PHASE = "P0" as const;

--- a/src/lib/apihub/health-body.test.ts
+++ b/src/lib/apihub/health-body.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { getApiHubHealthJson } from "./health-body";
+
+describe("getApiHubHealthJson", () => {
+  it("returns the P0 health contract", () => {
+    expect(getApiHubHealthJson()).toEqual({
+      ok: true,
+      service: "apihub",
+      phase: "P0",
+    });
+  });
+});

--- a/src/lib/apihub/health-body.ts
+++ b/src/lib/apihub/health-body.ts
@@ -1,0 +1,11 @@
+import { APIHUB_PHASE, APIHUB_SERVICE } from "./constants";
+
+export type ApiHubHealthJson = {
+  ok: true;
+  service: typeof APIHUB_SERVICE;
+  phase: typeof APIHUB_PHASE;
+};
+
+export function getApiHubHealthJson(): ApiHubHealthJson {
+  return { ok: true, service: APIHUB_SERVICE, phase: APIHUB_PHASE };
+}


### PR DESCRIPTION
## Summary

Implements [GitHub issue #16](https://github.com/lasealco/po-management/issues/16): API hub **P0** documentation polish, read-only **`/apihub`** app shell (demo session required), **`GET /api/apihub/health`**, `src/lib/apihub` health helper + Vitest, optional **command palette** entry for signed-in users, and **`docs/engineering/agent-todos/integration-hub.md`** updates (live spec home, P0 vs later, checkbox hygiene).

## Checklist (issue #16)

- [x] Docs: `docs/apihub/README.md`, `integrations-ai-assisted-ingestion.md`, `GAP_MAP.md`
- [x] Integration-hub todo file updated
- [x] UI: `/apihub` with workflow header, steps 1–5 placeholders, primary CTA uses `var(--arscmp-primary)`
- [x] API: `GET /api/apihub/health` → `{ ok, service, phase }`
- [x] Quality: `npm run lint && npx tsc --noEmit && npm run test`

## Notes

- No Prisma migrations or seeds.
- Does not merge to `main` from this PR branch (per issue).


Made with [Cursor](https://cursor.com)