### PR TITLE
feat(apihub): connector registry v1 (stub)

### DIFF
--- a/docs/apihub/GAP_MAP.md
+++ b/docs/apihub/GAP_MAP.md
@@ -2,22 +2,23 @@
 
 **Legend:** ✅ shipped · 🟡 partial / stub · ❌ not started
 
-**Last updated:** 2026-04-20 (P0 shell + health stub)
+**Last updated:** 2026-04-20 (Phase 1 connector registry stub)
 
 | Area | Repo reality | Notes |
 |------|--------------|--------|
 | Docs home | ✅ `docs/apihub/README.md`, specs | Cross-linked README + spec |
 | Ingestion spec | 🟡 `integrations-ai-assisted-ingestion.md` | Draft; evolves with P0–P4 |
-| App route `/apihub` | ✅ `src/app/apihub/**` | Read-only shell; demo session required |
+| App route `/apihub` | ✅ `src/app/apihub/**` | Shell + **Connectors** section (DB-backed list); demo session required |
 | Health / discovery API | ✅ `GET /api/apihub/health` | `{ ok, service, phase }`; no secrets |
-| Prisma: connector / template / batch | ❌ | P1 |
+| Prisma: **connector registry** | 🟡 `ApiHubConnector` + `GET/POST /api/apihub/connectors` | Phase 1 stub rows only; no secrets / OAuth / workers |
+| Prisma: template / batch / staging | ❌ | P1+ (remaining spec tables) |
 | AI job + mapping editor | ❌ | P2 |
 | Deterministic apply + idempotent API | ❌ | P3 |
 
 ## Near-term build order
 
 1. P0 — shell + health + docs links (see meeting-batch issue).
-2. P1 — data model + CRUD stubs.
+2. P1 — **connector registry** (this slice) + further CRUD stubs for template/batch as follow-ups.
 3. P2 — jobs + editor + staging preview.
 4. P3 — production apply + CT/PO/SO wiring per scenario.
 5. P4 — conflicts, match keys, hardening.

--- a/docs/apihub/README.md
+++ b/docs/apihub/README.md
@@ -12,10 +12,11 @@ This folder is the **documentation home** for **integration / ingestion APIs and
 
 **Gap map (spec ↔ code):** [GAP_MAP.md](./GAP_MAP.md)
 
-## In-app entry (P0)
+## In-app entry (P0+)
 
-- Authenticated demo session: **`/apihub`** (read-only shell; see [GAP_MAP](./GAP_MAP.md)).
-- **Health stub:** `GET /api/apihub/health` — JSON `{ ok, service, phase }` for discovery and deploy checks.
+- Authenticated demo session: **`/apihub`** — workflow placeholders + **Connectors** registry (Phase 1 stub list; see [GAP_MAP](./GAP_MAP.md)).
+- **Health stub:** `GET /api/apihub/health` — JSON `{ ok, service, phase }` for discovery and deploy checks (no auth).
+- **Connector registry (Phase 1):** `GET` / `POST` **`/api/apihub/connectors`** — demo tenant + active demo actor (same session gate as `/apihub`); returns metadata only (no secrets).
 
 ## Related material elsewhere
 

--- a/docs/engineering/agent-todos/integration-hub.md
+++ b/docs/engineering/agent-todos/integration-hub.md
@@ -25,7 +25,7 @@
 
 ## Phase 1 — contracts (after P0)
 
-- [ ] **Connector registry** — DB table + CRUD API stub + empty UI list (issue must include Prisma scope).
+- [x] **Connector registry** — `ApiHubConnector` + migration `20260420183000_apihub_connector_registry`; `GET`/`POST` `src/app/api/apihub/connectors/route.ts`; Connectors section on `/apihub` (Session 8 / Phase 1 stub).
 - [ ] **Health / last sync** — display-only fields on registry rows (mock data ok until integrations exist).
 - [ ] **Audit log slice** — who changed connector config (may reuse existing audit patterns).
 

--- a/prisma/migrations/20260420183000_apihub_connector_registry/migration.sql
+++ b/prisma/migrations/20260420183000_apihub_connector_registry/migration.sql
@@ -1,0 +1,21 @@
+-- API hub Phase 1: tenant-scoped connector registry (stub rows; no secrets)
+
+CREATE TABLE "ApiHubConnector" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL DEFAULT 'unspecified',
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "lastSyncAt" TIMESTAMP(3),
+    "healthSummary" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ApiHubConnector_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ApiHubConnector_tenantId_idx" ON "ApiHubConnector"("tenantId");
+
+CREATE INDEX "ApiHubConnector_tenantId_createdAt_idx" ON "ApiHubConnector"("tenantId", "createdAt");
+
+ALTER TABLE "ApiHubConnector" ADD CONSTRAINT "ApiHubConnector_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,28 @@ model Tenant {
   invoiceIntakes        InvoiceIntake[]
   invoiceToleranceRules InvoiceToleranceRule[]
   invoiceChargeAliases  InvoiceChargeAlias[]
+  apiHubConnectors      ApiHubConnector[]
+}
+
+/// Integration / API hub — registry row for an external or internal data source (Phase 1 stub).
+model ApiHubConnector {
+  id        String   @id @default(cuid())
+  tenantId  String
+  name      String
+  /// High-level source label until taxonomy lands (e.g. `stub`, `file`, `api`).
+  sourceKind String  @default("unspecified")
+  status    String   @default("draft")
+  /// Populated when sync jobs exist; nullable for stub rows.
+  lastSyncAt DateTime?
+  /// Operator-facing health / connectivity summary (no secrets).
+  healthSummary String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@index([tenantId, createdAt])
 }
 
 /// Tenant-scoped milestone template packs (override or extend built-in packs in code).

--- a/src/app/api/apihub/connectors/route.ts
+++ b/src/app/api/apihub/connectors/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+
+import { toApiHubConnectorDto } from "@/lib/apihub/connector-dto";
+import { createStubApiHubConnector, listApiHubConnectors } from "@/lib/apihub/connectors-repo";
+import { getActorUserId } from "@/lib/authz";
+import { getDemoTenant } from "@/lib/demo-tenant";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const tenant = await getDemoTenant();
+  if (!tenant) {
+    return NextResponse.json(
+      {
+        error:
+          "Demo tenant not found. Run `npm run db:seed` to create starter data.",
+      },
+      { status: 404 },
+    );
+  }
+
+  const actorId = await getActorUserId();
+  if (!actorId) {
+    return NextResponse.json(
+      {
+        error:
+          "No active demo user for this session. Open Settings → Demo session (/settings/demo) to choose who you are acting as.",
+      },
+      { status: 403 },
+    );
+  }
+
+  const rows = await listApiHubConnectors(tenant.id);
+  return NextResponse.json({ connectors: rows.map(toApiHubConnectorDto) });
+}
+
+type PostBody = {
+  name?: unknown;
+};
+
+export async function POST(request: Request) {
+  const tenant = await getDemoTenant();
+  if (!tenant) {
+    return NextResponse.json(
+      {
+        error:
+          "Demo tenant not found. Run `npm run db:seed` to create starter data.",
+      },
+      { status: 404 },
+    );
+  }
+
+  const actorId = await getActorUserId();
+  if (!actorId) {
+    return NextResponse.json(
+      {
+        error:
+          "No active demo user for this session. Open Settings → Demo session (/settings/demo) to choose who you are acting as.",
+      },
+      { status: 403 },
+    );
+  }
+
+  let body: PostBody = {};
+  try {
+    body = (await request.json()) as PostBody;
+  } catch {
+    body = {};
+  }
+
+  const rawName = typeof body.name === "string" ? body.name.trim() : "";
+  const name = rawName.length > 0 ? rawName.slice(0, 128) : "Stub connector";
+
+  const created = await createStubApiHubConnector({ tenantId: tenant.id, name });
+  return NextResponse.json({ connector: toApiHubConnectorDto(created) }, { status: 201 });
+}

--- a/src/app/apihub/apihub-header.tsx
+++ b/src/app/apihub/apihub-header.tsx
@@ -9,6 +9,9 @@ export function ApihubHeader() {
           <h1 className="text-base font-semibold text-zinc-900">API hub</h1>
         </div>
         <nav className="flex flex-wrap items-center justify-end gap-3 text-sm">
+          <Link href="/apihub#connectors" className="font-medium text-zinc-600 hover:text-zinc-900">
+            Connectors
+          </Link>
           <Link href="/settings/demo" className="font-medium text-zinc-600 hover:text-zinc-900">
             Demo session
           </Link>

--- a/src/app/apihub/connectors-section.tsx
+++ b/src/app/apihub/connectors-section.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import type { ApiHubConnectorDto } from "@/lib/apihub/connector-dto";
+
+type Props = {
+  initialConnectors: ApiHubConnectorDto[];
+  canCreate: boolean;
+};
+
+function formatWhen(iso: string) {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function ConnectorsSection({ initialConnectors, canCreate }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function addStub() {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await fetch("/api/apihub/connectors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Could not create connector.");
+        return;
+      }
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section
+      id="connectors"
+      className="mt-10 rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">Phase 1</p>
+          <h2 className="mt-1 text-xl font-semibold text-zinc-900">Connectors</h2>
+          <p className="mt-2 max-w-2xl text-sm text-zinc-600">
+            Registry rows for partner or internal sources. This build stores{" "}
+            <span className="font-medium">metadata only</span> — no secrets, OAuth, or background sync yet.
+          </p>
+        </div>
+        {canCreate ? (
+          <button
+            type="button"
+            onClick={() => void addStub()}
+            disabled={busy}
+            className="inline-flex shrink-0 items-center justify-center rounded-xl bg-[var(--arscmp-primary)] px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:brightness-95 disabled:opacity-60"
+          >
+            {busy ? "Adding…" : "Add stub connector"}
+          </button>
+        ) : (
+          <p className="max-w-xs text-right text-sm text-zinc-600">
+            Choose a demo user in{" "}
+            <a href="/settings/demo" className="font-medium text-[var(--arscmp-primary)] hover:underline">
+              Settings → Demo session
+            </a>{" "}
+            to create registry rows via the API.
+          </p>
+        )}
+      </div>
+
+      {error ? (
+        <p className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {initialConnectors.length === 0 ? (
+        <div className="mt-6 rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-8 text-center text-sm text-zinc-600">
+          <p className="font-medium text-zinc-800">No connectors yet</p>
+          <p className="mt-2">
+            {canCreate
+              ? "Use “Add stub connector” to insert a draft row for UI and API checks."
+              : "Once a demo session is active, you can add stub rows from this page or POST /api/apihub/connectors."}
+          </p>
+        </div>
+      ) : (
+        <div className="mt-6 overflow-x-auto rounded-xl border border-zinc-200">
+          <table className="min-w-full divide-y divide-zinc-200 text-left text-sm">
+            <thead className="bg-zinc-50 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+              <tr>
+                <th className="px-4 py-3">Name</th>
+                <th className="px-4 py-3">Kind</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Last sync</th>
+                <th className="px-4 py-3">Health</th>
+                <th className="px-4 py-3">Updated</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-100 bg-white text-zinc-800">
+              {initialConnectors.map((c) => (
+                <tr key={c.id}>
+                  <td className="px-4 py-3 font-medium">{c.name}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-zinc-600">{c.sourceKind}</td>
+                  <td className="px-4 py-3">{c.status}</td>
+                  <td className="px-4 py-3 text-zinc-600">{c.lastSyncAt ? formatWhen(c.lastSyncAt) : "—"}</td>
+                  <td className="px-4 py-3 text-zinc-600">{c.healthSummary ?? "—"}</td>
+                  <td className="px-4 py-3 text-zinc-600">{formatWhen(c.updatedAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="mt-4 text-xs text-zinc-500">
+        API: <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono">GET /api/apihub/connectors</code>,{" "}
+        <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono">POST /api/apihub/connectors</code> (demo tenant +
+        demo actor required; same gate as listing above).
+      </p>
+    </section>
+  );
+}

--- a/src/app/apihub/page.tsx
+++ b/src/app/apihub/page.tsx
@@ -1,5 +1,11 @@
 import Link from "next/link";
 
+import { toApiHubConnectorDto } from "@/lib/apihub/connector-dto";
+import { listApiHubConnectors } from "@/lib/apihub/connectors-repo";
+import { getViewerGrantSet } from "@/lib/authz";
+
+import { ConnectorsSection } from "./connectors-section";
+
 export const dynamic = "force-dynamic";
 
 const GITHUB_DOCS_APIHUB_TREE =
@@ -35,7 +41,13 @@ const STEP_PLACEHOLDERS = [
   },
 ] as const;
 
-export default function ApihubHomePage() {
+export default async function ApihubHomePage() {
+  const access = await getViewerGrantSet();
+  const canCreate = Boolean(access?.user);
+  const connectorRows =
+    access?.user && access.tenant ? await listApiHubConnectors(access.tenant.id) : [];
+  const initialConnectors = connectorRows.map(toApiHubConnectorDto);
+
   return (
     <main className="mx-auto max-w-5xl px-6 py-10">
       <section className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
@@ -45,9 +57,10 @@ export default function ApihubHomePage() {
             <h2 className="text-2xl font-semibold text-zinc-900">Integration and ingestion hub</h2>
             <p className="mt-2 max-w-2xl text-sm text-zinc-600">
               Single place for AI-assisted mapping proposals, human confirmation, and repeatable runs across file
-              upload and server-to-server APIs. This page is a{" "}
-              <span className="font-medium text-zinc-800">Phase P0</span> shell: documentation and UX scaffolding only
-              — no connector database or live ingestion yet.
+              upload and server-to-server APIs. The workflow cards below remain{" "}
+              <span className="font-medium text-zinc-800">placeholders</span>;{" "}
+              <span className="font-medium text-zinc-800">Phase 1</span> adds a tenant-scoped connector registry (stub
+              rows, no live ingestion).
             </p>
           </div>
           <div className="flex flex-col gap-2 sm:items-end">
@@ -96,6 +109,8 @@ export default function ApihubHomePage() {
           .
         </div>
       </section>
+
+      <ConnectorsSection initialConnectors={initialConnectors} canCreate={canCreate} />
     </main>
   );
 }

--- a/src/lib/apihub/connector-dto.test.ts
+++ b/src/lib/apihub/connector-dto.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { toApiHubConnectorDto } from "./connector-dto";
+
+describe("toApiHubConnectorDto", () => {
+  it("serializes dates to ISO strings and null lastSyncAt", () => {
+    const created = new Date("2026-04-20T12:00:00.000Z");
+    const updated = new Date("2026-04-20T15:30:00.000Z");
+    const out = toApiHubConnectorDto({
+      id: "c1",
+      name: "Test",
+      sourceKind: "stub",
+      status: "draft",
+      lastSyncAt: null,
+      healthSummary: "ok",
+      createdAt: created,
+      updatedAt: updated,
+    });
+    expect(out.lastSyncAt).toBeNull();
+    expect(out.createdAt).toBe("2026-04-20T12:00:00.000Z");
+    expect(out.updatedAt).toBe("2026-04-20T15:30:00.000Z");
+    expect(out.healthSummary).toBe("ok");
+  });
+});

--- a/src/lib/apihub/connector-dto.ts
+++ b/src/lib/apihub/connector-dto.ts
@@ -1,0 +1,34 @@
+export type ApiHubConnectorDto = {
+  id: string;
+  name: string;
+  sourceKind: string;
+  status: string;
+  lastSyncAt: string | null;
+  healthSummary: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type Row = {
+  id: string;
+  name: string;
+  sourceKind: string;
+  status: string;
+  lastSyncAt: Date | null;
+  healthSummary: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function toApiHubConnectorDto(row: Row): ApiHubConnectorDto {
+  return {
+    id: row.id,
+    name: row.name,
+    sourceKind: row.sourceKind,
+    status: row.status,
+    lastSyncAt: row.lastSyncAt ? row.lastSyncAt.toISOString() : null,
+    healthSummary: row.healthSummary,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/src/lib/apihub/connectors-repo.ts
+++ b/src/lib/apihub/connectors-repo.ts
@@ -1,0 +1,56 @@
+import { prisma } from "@/lib/prisma";
+
+const DEFAULT_STUB_HEALTH = "Not connected — stub row (Phase 1)";
+
+export type ApiHubConnectorListRow = {
+  id: string;
+  name: string;
+  sourceKind: string;
+  status: string;
+  lastSyncAt: Date | null;
+  healthSummary: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export async function listApiHubConnectors(tenantId: string): Promise<ApiHubConnectorListRow[]> {
+  return prisma.apiHubConnector.findMany({
+    where: { tenantId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      name: true,
+      sourceKind: true,
+      status: true,
+      lastSyncAt: true,
+      healthSummary: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+}
+
+export async function createStubApiHubConnector(opts: {
+  tenantId: string;
+  name: string;
+}): Promise<ApiHubConnectorListRow> {
+  return prisma.apiHubConnector.create({
+    data: {
+      tenantId: opts.tenantId,
+      name: opts.name,
+      sourceKind: "stub",
+      status: "draft",
+      healthSummary: DEFAULT_STUB_HEALTH,
+    },
+    select: {
+      id: true,
+      name: true,
+      sourceKind: true,
+      status: true,
+      lastSyncAt: true,
+      healthSummary: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
Session 8 — API hub Phase 1 connector registry (stub): Prisma model + migration, list/create API routes, and `/apihub` Connectors UI backed by the database.

## Migration
- `20260420183000_apihub_connector_registry` — creates `ApiHubConnector` (tenant-scoped, no secrets).

## API
- `GET /api/apihub/connectors` — JSON `{ connectors: [...] }` for `demo-company` when a demo actor is selected (same 403/404 messaging pattern as other demo-scoped APIs).
- `POST /api/apihub/connectors` — optional JSON body `{ "name": "..." }` (default name `Stub connector`); returns `{ connector }` with HTTP 201.

## UI
- `/apihub` includes a **Connectors** section (anchor `#connectors`) with table or empty state; **Add stub connector** uses the POST route and `router.refresh()`.
- Header nav link to `/apihub#connectors`.

## Docs
- `docs/apihub/GAP_MAP.md`, `docs/apihub/README.md`, `docs/engineering/agent-todos/integration-hub.md` updated for Phase 1.

## Issue
Replace with your GitHub issue when filed: **Session 8 / integration-hub Phase 1** (placeholder `#YOUR_ISSUE_NUMBER` — no `Closes` until Alex confirms).

## Out of scope (explicit)
- Job workers, secrets storage, OAuth, mapping editor (per Session 8 brief).

## Verify
`npm run lint`, `npx tsc --noEmit`, `npm run test` (local). `USE_DOTENV_LOCAL=1 npm run db:migrate` applied migration `20260420183000_apihub_connector_registry` against local Postgres in agent env.


Made with [Cursor](https://cursor.com)