### PR TITLE
Control Tower: exception catalog report dimension and open exceptions measure

### DIFF
--- a/src/components/control-tower-dashboard-chart-kit.tsx
+++ b/src/components/control-tower-dashboard-chart-kit.tsx
@@ -14,6 +14,7 @@ const CT_REPORT_MEASURES = [
   "shippingSpend",
   "onTimePct",
   "avgDelayDays",
+  "openExceptions",
 ] as const;
 type CtReportMeasure = (typeof CT_REPORT_MEASURES)[number];
 
@@ -79,6 +80,7 @@ export function formatInteger(value: number): string {
 
 export function formatAxisTick(measure: string, value: number): string {
   if (measure === "shipments") return formatInteger(value);
+  if (measure === "openExceptions") return formatInteger(value);
   if (measure === "onTimePct") return `${formatDecimal(value, 0)}%`;
   if (measure === "avgDelayDays") return formatDecimal(value, 1);
   return formatDecimal(value, 0);
@@ -86,6 +88,7 @@ export function formatAxisTick(measure: string, value: number): string {
 
 export function formatMetric(measure: string, value: number): string {
   if (measure === "shipments") return formatInteger(value);
+  if (measure === "openExceptions") return formatInteger(value);
   if (measure === "onTimePct") return `${formatDecimal(value, 2)}%`;
   if (measure === "shippingSpend") return formatDecimal(value, 2);
   if (measure === "avgDelayDays") return formatDecimal(value, 2);
@@ -1061,7 +1064,9 @@ export function ControlTowerDashboardWidgetModal(props: {
                 rowKey={drillRow.key}
                 rowLabel={drillRow.label}
                 ship360Tab={
-                  report.config.measure === "onTimePct" || report.config.measure === "avgDelayDays"
+                  report.config.measure === "onTimePct" ||
+                  report.config.measure === "avgDelayDays" ||
+                  report.config.dimension === "exceptionCatalog"
                     ? "milestones"
                     : undefined
                 }

--- a/src/components/control-tower-report-builder.tsx
+++ b/src/components/control-tower-report-builder.tsx
@@ -7,7 +7,14 @@ import { WorkbenchDrillLink } from "@/components/workbench-drill-link";
 import { buildControlTowerReportCsv } from "@/lib/control-tower/report-csv";
 import type { ReportInsightRunSummary } from "@/lib/control-tower/report-run-summary";
 
-type Measure = "shipments" | "volumeCbm" | "weightKg" | "shippingSpend" | "onTimePct" | "avgDelayDays";
+type Measure =
+  | "shipments"
+  | "volumeCbm"
+  | "weightKg"
+  | "shippingSpend"
+  | "onTimePct"
+  | "avgDelayDays"
+  | "openExceptions";
 type Dimension =
   | "none"
   | "status"
@@ -18,7 +25,8 @@ type Dimension =
   | "supplier"
   | "origin"
   | "destination"
-  | "month";
+  | "month"
+  | "exceptionCatalog";
 type ChartType = "table" | "bar" | "line" | "pie";
 
 type ReportConfig = {
@@ -41,6 +49,7 @@ type ReportConfig = {
     supplierId: string;
     origin: string;
     destination: string;
+    onlyOpenExceptions: boolean;
   };
 };
 
@@ -104,6 +113,7 @@ const MEASURE_LABELS: Record<Measure, string> = {
   shippingSpend: "Shipping spend",
   onTimePct: "On-time %",
   avgDelayDays: "Avg delay (days)",
+  openExceptions: "Open exceptions",
 };
 
 const DEFAULT_CONFIG: ReportConfig = {
@@ -126,6 +136,7 @@ const DEFAULT_CONFIG: ReportConfig = {
     supplierId: "",
     origin: "",
     destination: "",
+    onlyOpenExceptions: false,
   },
 };
 
@@ -164,6 +175,7 @@ function hydrateConfig(input: unknown): ReportConfig {
       supplierId: typeof filters.supplierId === "string" ? filters.supplierId : "",
       origin: typeof filters.origin === "string" ? filters.origin : "",
       destination: typeof filters.destination === "string" ? filters.destination : "",
+      onlyOpenExceptions: filters.onlyOpenExceptions === true,
     },
   };
 }
@@ -193,13 +205,22 @@ function compareRange(config: ReportConfig): { from: string; to: string } | null
 }
 
 function toRunPayload(config: ReportConfig) {
+  const f = config.filters;
   return {
     ...config,
     dateFrom: config.dateFrom || null,
     dateTo: config.dateTo || null,
-    filters: Object.fromEntries(
-      Object.entries(config.filters).map(([k, v]) => [k, v.trim() || null]),
-    ),
+    filters: {
+      status: f.status.trim() || null,
+      mode: f.mode.trim() || null,
+      lane: f.lane.trim() || null,
+      carrierSupplierId: f.carrierSupplierId.trim() || null,
+      customerCrmAccountId: f.customerCrmAccountId.trim() || null,
+      supplierId: f.supplierId.trim() || null,
+      origin: f.origin.trim() || null,
+      destination: f.destination.trim() || null,
+      ...(f.onlyOpenExceptions ? { onlyOpenExceptions: true as const } : {}),
+    },
   };
 }
 
@@ -207,6 +228,7 @@ function formatMetric(measure: Measure, value: number): string {
   if (measure === "onTimePct") return `${value.toFixed(2)}%`;
   if (measure === "shippingSpend") return `$${value.toFixed(2)}`;
   if (measure === "avgDelayDays") return `${value.toFixed(2)}d`;
+  if (measure === "openExceptions") return String(Math.round(value));
   return value.toLocaleString();
 }
 
@@ -1050,10 +1072,29 @@ export function ControlTowerReportBuilder({
                 Group by
                 <select
                   value={config.dimension}
-                  onChange={(e) => setConfig((c) => ({ ...c, dimension: e.target.value as Dimension }))}
+                  onChange={(e) => {
+                    const dimension = e.target.value as Dimension;
+                    setConfig((c) => ({
+                      ...c,
+                      dimension,
+                      measure: dimension === "exceptionCatalog" ? "openExceptions" : c.measure,
+                    }));
+                  }}
                   className="mt-1.5 w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-800"
                 >
-                  {["month", "lane", "carrier", "customer", "supplier", "status", "mode", "origin", "destination", "none"].map((d) => (
+                  {[
+                    "month",
+                    "lane",
+                    "carrier",
+                    "customer",
+                    "supplier",
+                    "status",
+                    "mode",
+                    "origin",
+                    "destination",
+                    "exceptionCatalog",
+                    "none",
+                  ].map((d) => (
                     <option key={d} value={d}>
                       {d}
                     </option>
@@ -1210,6 +1251,21 @@ export function ControlTowerReportBuilder({
                 </select>
               </label>
             </div>
+
+            <label className="mt-3 flex cursor-pointer items-center gap-2 text-xs text-zinc-700">
+              <input
+                type="checkbox"
+                checked={config.filters.onlyOpenExceptions}
+                onChange={(e) =>
+                  setConfig((c) => ({
+                    ...c,
+                    filters: { ...c.filters, onlyOpenExceptions: e.target.checked },
+                  }))
+                }
+                className="h-4 w-4 rounded border-zinc-300 text-[var(--arscmp-primary)] focus:ring-[var(--arscmp-primary)]"
+              />
+              <span>Only shipments with open exceptions (OPEN / IN_PROGRESS)</span>
+            </label>
           </div>
         </div>
 
@@ -1433,7 +1489,9 @@ export function ControlTowerReportBuilder({
                 rowKey={chartDrillRow.key}
                 rowLabel={chartDrillRow.label}
                 ship360Tab={
-                  result.config.measure === "onTimePct" || result.config.measure === "avgDelayDays"
+                  result.config.measure === "onTimePct" ||
+                  result.config.measure === "avgDelayDays" ||
+                  result.config.dimension === "exceptionCatalog"
                     ? "milestones"
                     : undefined
                 }

--- a/src/lib/control-tower/report-csv.ts
+++ b/src/lib/control-tower/report-csv.ts
@@ -9,6 +9,7 @@ export const REPORT_CSV_MEASURES = [
   "shippingSpend",
   "onTimePct",
   "avgDelayDays",
+  "openExceptions",
 ] as const;
 
 export type ReportCsvRow = { label: string; metrics: Record<string, number> };

--- a/src/lib/control-tower/report-engine-exception-bucket.test.ts
+++ b/src/lib/control-tower/report-engine-exception-bucket.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { exceptionCatalogBucket, normalizeExceptionTypeKey } from "./report-engine";
+
+describe("normalizeExceptionTypeKey", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeExceptionTypeKey("  LATE_DOC  ")).toBe("late_doc");
+  });
+});
+
+describe("exceptionCatalogBucket", () => {
+  const catalog = new Map<string, { code: string; label: string }>([
+    ["late_doc", { code: "LATE_DOC", label: "Late documentation" }],
+  ]);
+
+  it("maps raw type to catalog code and label", () => {
+    expect(
+      exceptionCatalogBucket({
+        rawType: "late_doc",
+        catalogByNormalizedCode: catalog,
+      }),
+    ).toEqual({ rowKey: "LATE_DOC", rowLabel: "Late documentation (LATE_DOC)" });
+  });
+
+  it("matches catalog by case-insensitive code", () => {
+    expect(
+      exceptionCatalogBucket({
+        rawType: "LaTe_DoC",
+        catalogByNormalizedCode: catalog,
+      }),
+    ).toEqual({ rowKey: "LATE_DOC", rowLabel: "Late documentation (LATE_DOC)" });
+  });
+
+  it("returns unlisted bucket when not in catalog", () => {
+    expect(
+      exceptionCatalogBucket({
+        rawType: "CUSTOM-XYZ",
+        catalogByNormalizedCode: catalog,
+      }),
+    ).toEqual({ rowKey: "CUSTOM-XYZ", rowLabel: "Unlisted (CUSTOM-XYZ)" });
+  });
+
+  it("handles blank raw type", () => {
+    expect(
+      exceptionCatalogBucket({
+        rawType: "   ",
+        catalogByNormalizedCode: catalog,
+      }),
+    ).toEqual({ rowKey: "(blank)", rowLabel: "Blank type" });
+  });
+});

--- a/src/lib/control-tower/report-engine.ts
+++ b/src/lib/control-tower/report-engine.ts
@@ -1,4 +1,4 @@
-import type { Prisma, ShipmentStatus, TransportMode } from "@prisma/client";
+import { CtExceptionStatus, type Prisma, type ShipmentStatus, type TransportMode } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { convertAmount, minorToAmount, normalizeCurrency } from "@/lib/control-tower/currency";
@@ -21,6 +21,7 @@ export const CT_REPORT_DIMENSIONS = [
   "origin",
   "destination",
   "month",
+  "exceptionCatalog",
 ] as const;
 export type CtReportDimension = (typeof CT_REPORT_DIMENSIONS)[number];
 
@@ -31,6 +32,7 @@ export const CT_REPORT_MEASURES = [
   "shippingSpend",
   "onTimePct",
   "avgDelayDays",
+  "openExceptions",
 ] as const;
 export type CtReportMeasure = (typeof CT_REPORT_MEASURES)[number];
 
@@ -67,6 +69,7 @@ export type CtReportConfig = {
     supplierId?: string | null;
     origin?: string | null;
     destination?: string | null;
+    onlyOpenExceptions?: boolean;
   };
   topN?: number;
 };
@@ -132,6 +135,25 @@ function nonEmpty(v: string | null | undefined): string | null {
   return t ? t : null;
 }
 
+export function normalizeExceptionTypeKey(type: string): string {
+  return type.trim().toLowerCase();
+}
+
+export function exceptionCatalogBucket(params: {
+  rawType: string;
+  catalogByNormalizedCode: Map<string, { code: string; label: string }>;
+}): { rowKey: string; rowLabel: string } {
+  const t = params.rawType.trim();
+  if (!t) {
+    return { rowKey: "(blank)", rowLabel: "Blank type" };
+  }
+  const hit = params.catalogByNormalizedCode.get(normalizeExceptionTypeKey(t));
+  if (hit) {
+    return { rowKey: hit.code, rowLabel: `${hit.label} (${hit.code})` };
+  }
+  return { rowKey: t, rowLabel: `Unlisted (${t})` };
+}
+
 export function sanitizeCtReportConfig(input: unknown): CtReportConfig {
   const o = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
   const chartType = CT_REPORT_CHARTS.includes(o.chartType as CtReportChartType)
@@ -140,9 +162,10 @@ export function sanitizeCtReportConfig(input: unknown): CtReportConfig {
   const dimension = CT_REPORT_DIMENSIONS.includes(o.dimension as CtReportDimension)
     ? (o.dimension as CtReportDimension)
     : "month";
-  const measure = CT_REPORT_MEASURES.includes(o.measure as CtReportMeasure)
+  let measure = CT_REPORT_MEASURES.includes(o.measure as CtReportMeasure)
     ? (o.measure as CtReportMeasure)
     : "shipments";
+  if (dimension === "exceptionCatalog") measure = "openExceptions";
   const compareMeasure = CT_REPORT_MEASURES.includes(o.compareMeasure as CtReportMeasure)
     ? (o.compareMeasure as CtReportMeasure)
     : null;
@@ -175,6 +198,7 @@ export function sanitizeCtReportConfig(input: unknown): CtReportConfig {
       supplierId: typeof filtersObj.supplierId === "string" ? filtersObj.supplierId : null,
       origin: typeof filtersObj.origin === "string" ? filtersObj.origin : null,
       destination: typeof filtersObj.destination === "string" ? filtersObj.destination : null,
+      onlyOpenExceptions: filtersObj.onlyOpenExceptions === true,
     },
   };
 }
@@ -206,6 +230,7 @@ type ShipmentRow = {
     amountMinor: bigint;
     currency: string;
   }>;
+  ctExceptions: Array<{ type: string }>;
 };
 
 function decimalToNumber(v: Prisma.Decimal | null | undefined): number {
@@ -251,6 +276,8 @@ function rowDimensionValue(row: ShipmentRow, dim: CtReportDimension): string {
       return row.booking?.destinationCode || "Unknown";
     case "month":
       return monthKey(row.shippedAt);
+    case "exceptionCatalog":
+      return "—";
   }
 }
 
@@ -262,6 +289,7 @@ function makeZeroMetrics(): Record<CtReportMeasure, number> {
     shippingSpend: 0,
     onTimePct: 0,
     avgDelayDays: 0,
+    openExceptions: 0,
   };
 }
 
@@ -299,6 +327,13 @@ export async function runControlTowerReport(params: {
         { booking: { is: { originCode: { contains: lane, mode: "insensitive" } } } },
         { booking: { is: { destinationCode: { contains: lane, mode: "insensitive" } } } },
       ],
+    });
+  }
+  if (filters.onlyOpenExceptions === true) {
+    ands.push({
+      ctExceptions: {
+        some: { status: { in: [CtExceptionStatus.OPEN, CtExceptionStatus.IN_PROGRESS] } },
+      },
     });
   }
   const dateField = config.dateField ?? "shippedAt";
@@ -350,8 +385,29 @@ export async function runControlTowerReport(params: {
       ctCostLines: {
         select: { amountMinor: true, currency: true },
       },
+      ctExceptions: {
+        where: { status: { in: [CtExceptionStatus.OPEN, CtExceptionStatus.IN_PROGRESS] } },
+        select: { type: true },
+      },
     },
   })) as ShipmentRow[];
+
+  const dim = config.dimension ?? "month";
+  const catalogByNorm =
+    dim === "exceptionCatalog"
+      ? new Map(
+          (
+            await prisma.ctExceptionCode.findMany({
+              where: { tenantId: params.tenantId, isActive: true },
+              select: { code: true, label: true },
+              orderBy: [{ sortOrder: "asc" }, { code: "asc" }],
+            })
+          ).map((c) => [
+            normalizeExceptionTypeKey(c.code),
+            { code: c.code.trim(), label: c.label.trim() },
+          ]),
+        )
+      : null;
 
   let displayCurrency = "USD";
   if (params.actorUserId) {
@@ -409,9 +465,27 @@ export async function runControlTowerReport(params: {
       continue;
     }
     shipmentsAggregated += 1;
-    const key = rowDimensionValue(r, config.dimension ?? "month");
+
+    if (dim === "exceptionCatalog" && catalogByNorm) {
+      for (const exc of r.ctExceptions) {
+        const raw = exc.type?.trim() ?? "";
+        if (!raw) continue;
+        const { rowKey, rowLabel } = exceptionCatalogBucket({
+          rawType: raw,
+          catalogByNormalizedCode: catalogByNorm,
+        });
+        const existing = grouped.get(rowKey) ?? { key: rowKey, label: rowLabel, metrics: makeZeroMetrics() };
+        existing.label = rowLabel;
+        existing.metrics.openExceptions += 1;
+        grouped.set(rowKey, existing);
+      }
+      continue;
+    }
+
+    const key = rowDimensionValue(r, dim);
     const existing = grouped.get(key) ?? { key, label: key, metrics: makeZeroMetrics() };
     existing.metrics.shipments += 1;
+    existing.metrics.openExceptions += r.ctExceptions.length;
     existing.metrics.volumeCbm += decimalToNumber(r.estimatedVolumeCbm);
     existing.metrics.weightKg += decimalToNumber(r.estimatedWeightKg);
     if (r.ctCostLines.length > 0) {
@@ -450,12 +524,12 @@ export async function runControlTowerReport(params: {
   });
 
   normalized.sort((a, b) => {
-    if (config.dimension === "month") return a.key.localeCompare(b.key);
+    if (dim === "month") return a.key.localeCompare(b.key);
     const m = config.measure ?? "shipments";
     return (b.metrics[m] ?? 0) - (a.metrics[m] ?? 0);
   });
 
-  const sliced = config.dimension === "month" ? normalized : normalized.slice(0, config.topN ?? 12);
+  const sliced = dim === "month" ? normalized : normalized.slice(0, config.topN ?? 12);
   const coverage: CtReportCoverage = {
     totalShipmentsQueried: rows.length,
     shipmentsAggregated,
@@ -473,7 +547,7 @@ export async function runControlTowerReport(params: {
     config: {
       title: config.title,
       chartType: config.chartType ?? "bar",
-      dimension: config.dimension ?? "month",
+      dimension: dim,
       measure: config.measure ?? "shipments",
       compareMeasure: config.compareMeasure ?? null,
       dateField: config.dateField ?? "shippedAt",

--- a/src/lib/control-tower/report-insight-llm.ts
+++ b/src/lib/control-tower/report-insight-llm.ts
@@ -8,6 +8,7 @@ const MEASURE_LABELS: Record<string, string> = {
   shippingSpend: "Shipping spend",
   onTimePct: "On-time %",
   avgDelayDays: "Avg delay (days)",
+  openExceptions: "Open exceptions (count)",
 };
 
 function truncate(s: string, max: number): string {

--- a/src/lib/control-tower/report-labels.ts
+++ b/src/lib/control-tower/report-labels.ts
@@ -9,6 +9,7 @@ export function metricLabel(measure: string): string {
   if (measure === "avgDelayDays") return "Avg delay (days)";
   if (measure === "volumeCbm") return "Volume (CBM)";
   if (measure === "weightKg") return "Weight (kg)";
+  if (measure === "openExceptions") return "Open exceptions (count)";
   return "Shipments";
 }
 
@@ -23,6 +24,7 @@ export function dimensionLabel(dimension: string): string {
   if (dimension === "mode") return "Mode";
   if (dimension === "status") return "Status";
   if (dimension === "none") return "All";
+  if (dimension === "exceptionCatalog") return "Exception catalog (code)";
   return "Category";
 }
 

--- a/src/lib/control-tower/report-pdf.ts
+++ b/src/lib/control-tower/report-pdf.ts
@@ -43,6 +43,8 @@ function abbrevMeasure(key: (typeof REPORT_CSV_MEASURES)[number]): string {
       return "OT%";
     case "avgDelayDays":
       return "Dly";
+    case "openExceptions":
+      return "Exc";
     default:
       return key;
   }
@@ -55,6 +57,7 @@ function fmtCell(key: (typeof REPORT_CSV_MEASURES)[number], n: number): string {
   if (key === "volumeCbm") return n.toFixed(1);
   if (key === "weightKg") return n.toFixed(0);
   if (key === "avgDelayDays") return n.toFixed(1);
+  if (key === "openExceptions") return String(Math.round(n));
   return String(Math.round(n));
 }
 

--- a/src/lib/control-tower/report-schedule-delivery.ts
+++ b/src/lib/control-tower/report-schedule-delivery.ts
@@ -80,7 +80,7 @@ export function formatReportRunForEmail(
     ...(dateWindowLine ? [dateWindowLine] : []),
     ...(compareLine ? [compareLine] : []),
     "",
-    `Totals — shipments: ${result.totals.shipments}, volume cbm: ${result.totals.volumeCbm.toFixed(2)}, weight kg: ${result.totals.weightKg.toFixed(1)}, shipping spend: ${result.totals.shippingSpend.toFixed(2)}`,
+    `Totals — shipments: ${result.totals.shipments}, open exceptions: ${result.totals.openExceptions}, volume cbm: ${result.totals.volumeCbm.toFixed(2)}, weight kg: ${result.totals.weightKg.toFixed(1)}, shipping spend: ${result.totals.shippingSpend.toFixed(2)}`,
     "",
     "Top rows:",
   ];

--- a/src/lib/control-tower/workbench-drill-from-report.ts
+++ b/src/lib/control-tower/workbench-drill-from-report.ts
@@ -107,6 +107,13 @@ export function buildControlTowerWorkbenchDrillQuery(params: {
     return withShip360Tab(sp, params.ship360Tab);
   }
 
+  if (dim === "exceptionCatalog") {
+    if (!key || key === "(blank)") return null;
+    if (key.length > 80 || !/^[\w.-]+$/i.test(key)) return null;
+    sp.set("exceptionCode", key);
+    return withShip360Tab(sp, params.ship360Tab);
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
Implements GitHub issue [#5](https://github.com/lasealco/po-management/issues/5) (report engine phase 1): aggregate by **exception catalog** (code + label) with measure **open exceptions** (count of `CtException` rows in **OPEN** / **IN_PROGRESS**, aligned with workbench semantics). Optional **only shipments with open exceptions** filter.

## Changes
- `report-engine`: dimension `exceptionCatalog`, measure `openExceptions`, catalog lookup via `ctExceptionCode`, per-exception-row counting, `onlyOpenExceptions` filter, exported `normalizeExceptionTypeKey` / `exceptionCatalogBucket`.
- Builder: dimension + measure types, group-by option, checkbox filter, safe `toRunPayload` filters (booleans not trimmed).
- CSV / PDF / scheduled email / chart kit / insight LLM / labels: include `openExceptions` and catalog dimension labels where applicable.
- Workbench drill: `exceptionCatalog` rows with drillable codes map to `exceptionCode` query param (same token rules as workbench).

## Tests
- `src/lib/control-tower/report-engine-exception-bucket.test.ts` (pure bucketing logic).
- `npm run lint`, `npx tsc --noEmit`, `npm run test` passed locally.

Alex: review and merge when ready (no auto-close).

Made with [Cursor](https://cursor.com)