### PR TITLE
docs(apihub): add API Hub docs runbook

### DIFF
--- a/docs/apihub/GAP_MAP.md
+++ b/docs/apihub/GAP_MAP.md
@@ -2,11 +2,12 @@
 
 **Legend:** ✅ shipped · 🟡 partial / stub · ❌ not started
 
-**Last updated:** 2026-04-20 (Phase 1 connector registry stub)
+**Last updated:** 2026-04-20 (Phase 1 connector registry stub + docs runbook)
 
 | Area | Repo reality | Notes |
 |------|--------------|--------|
 | Docs home | ✅ `docs/apihub/README.md`, specs | Cross-linked README + spec |
+| Docs runbook | ✅ `docs/apihub/RUNBOOK.md` | Docs-only workflow/checklist for API Hub issues |
 | Ingestion spec | 🟡 `integrations-ai-assisted-ingestion.md` | Draft; evolves with P0–P4 |
 | App route `/apihub` | ✅ `src/app/apihub/**` | Shell + **Connectors** section (DB-backed list); demo session required |
 | Health / discovery API | ✅ `GET /api/apihub/health` | `{ ok, service, phase }`; no secrets |

--- a/docs/apihub/README.md
+++ b/docs/apihub/README.md
@@ -9,6 +9,7 @@ This folder is the **documentation home** for **integration / ingestion APIs and
 | Document | Purpose |
 |----------|---------|
 | [integrations-ai-assisted-ingestion.md](./integrations-ai-assisted-ingestion.md) | End-to-end product + technical spec: AI-assisted ingestion, templates, API + file parity, guardrails, phased delivery |
+| [RUNBOOK.md](./RUNBOOK.md) | Docs-only execution runbook for API Hub updates, scope boundaries, and PR checklist |
 
 **Gap map (spec ↔ code):** [GAP_MAP.md](./GAP_MAP.md)
 

--- a/docs/apihub/RUNBOOK.md
+++ b/docs/apihub/RUNBOOK.md
@@ -1,0 +1,71 @@
+# API Hub docs runbook
+
+This runbook defines the repeatable workflow for docs-only API Hub updates. Use it for issue-driven docs maintenance, spec updates, and gap map hygiene without touching app or Prisma code.
+
+## Scope
+
+- In scope: `docs/apihub/**` and `docs/engineering/agent-todos/integration-hub.md`.
+- Out of scope for this runbook: `src/**`, `prisma/**`, migrations, or runtime behavior.
+- Primary audience: maintainers handling API Hub documentation issues and PRs.
+
+## Inputs before starting
+
+1. Confirm issue scope (what changed in product direction, contract, or phase status).
+2. Confirm current docs baseline:
+   - `docs/apihub/README.md`
+   - `docs/apihub/integrations-ai-assisted-ingestion.md`
+   - `docs/apihub/GAP_MAP.md`
+   - `docs/engineering/agent-todos/integration-hub.md`
+3. Confirm target branch naming for the wave/session task and PR base (`origin/main` unless requested otherwise).
+
+## Execution workflow
+
+### 1) Update canonical spec content first
+
+- Apply product/engineering decisions in `integrations-ai-assisted-ingestion.md`.
+- Keep phased table and open decisions aligned with current delivery reality.
+- Avoid speculative implementation details that are not approved.
+
+### 2) Update docs home links and entry points
+
+- Reflect new or renamed docs in `README.md`.
+- Keep "In-app entry" notes factual (what exists today vs planned).
+- Ensure GitHub links and relative links resolve.
+
+### 3) Update gap map truth table
+
+- Refresh `GAP_MAP.md`:
+  - `Last updated` date.
+  - Legend state per area (shipped/partial/not started).
+  - Notes that clearly separate shipped behavior from stubs.
+- Keep near-term build order consistent with the phased table in the spec.
+
+### 4) Sync engineering todo cross-links
+
+- Update `docs/engineering/agent-todos/integration-hub.md` when doc locations, scope notes, or phase checkpoints changed.
+- Keep suggested allowed paths and phase language consistent with the docs set.
+
+## Quality checks before PR
+
+- Link check by inspection:
+  - All relative markdown links resolve.
+  - Any GitHub links point to the correct repo path.
+- Consistency check:
+  - README, full spec, and GAP_MAP do not contradict each other.
+  - Phase labels (P0-P4) match across docs.
+- Scope check:
+  - Diff only includes allowed docs paths for docs-only issues.
+
+## PR checklist (docs-only API Hub issue)
+
+- Branch created from `origin/main` with requested naming.
+- Commit message uses concise imperative wording and API Hub scope.
+- PR body includes:
+  - Summary of docs changes.
+  - Explicit statement that no `src/**` or `prisma/**` files were modified.
+  - Any follow-up work items still open.
+- PR opened and left unmerged for review.
+
+## Change log guidance
+
+When a docs issue lands, add a short note in the touched doc sections that changed intent or status materially (for example, a date refresh in `GAP_MAP.md` and a short scope clarifier in `integration-hub.md`).

--- a/docs/engineering/agent-todos/integration-hub.md
+++ b/docs/engineering/agent-todos/integration-hub.md
@@ -7,6 +7,7 @@
 - **Documentation home:** [`docs/apihub/README.md`](../../apihub/README.md) — ingestion / integration API hub overview, GitHub links, in-app entry.
 - **Full draft spec:** [`docs/apihub/integrations-ai-assisted-ingestion.md`](../../apihub/integrations-ai-assisted-ingestion.md) — product + technical contract (supersedes informal one-pager requests; iterate here and in PRs).
 - **Gap map:** [`docs/apihub/GAP_MAP.md`](../../apihub/GAP_MAP.md) — what is shipped vs stub vs not started.
+- **Docs runbook:** [`docs/apihub/RUNBOOK.md`](../../apihub/RUNBOOK.md) — docs-only execution flow, scope guardrails, and PR checklist.
 
 **P0 (meeting batch):** docs polish + read-only **`/apihub`** shell + **`GET /api/apihub/health`** — no Prisma / migrations unless explicitly approved. **P1+:** connector registry, jobs, mapping editor, deterministic apply — see spec phased delivery §8.
 


### PR DESCRIPTION
## Summary
- add `docs/apihub/RUNBOOK.md` with a docs-only API Hub workflow, scope guardrails, and PR checklist
- cross-link the runbook from `docs/apihub/README.md` and `docs/engineering/agent-todos/integration-hub.md`
- update `docs/apihub/GAP_MAP.md` to track the new docs runbook artifact

## Test plan
- [x] verify changed paths are docs-only (`docs/apihub/**` and `docs/engineering/agent-todos/integration-hub.md`)
- [x] verify markdown links to `RUNBOOK.md` resolve from updated docs
- [x] confirm no `src/**` or `prisma/**` files changed

Made with [Cursor](https://cursor.com)