### PR TITLE
feat(control-tower): report phase 2 exception filter + docs sync

### DIFF
--- a/docs/controltower/GAP_MAP.md
+++ b/docs/controltower/GAP_MAP.md
@@ -136,8 +136,9 @@ Use this list when slicing PRs; refresh it whenever Control Tower behavior or `r
    - **Next smallest slice:** **multi-select + one bulk action** (e.g. acknowledge alerts or assign ops owner) with the same tenant scoping as single-row POST actions — **or** **server-stored default column visibility** per actor if ops consistency matters more than throughput.
 7. **(Low priority)** **Report builder — exception / “NC” style analytics**
    - **Done elsewhere:** exceptions are first-class in **workbench**, **search**, **Shipment 360**, and **exception catalog** (`CtException` / `CtExceptionCode`); list/search APIs accept **`exceptionCode`** / **`alertType`** for open-queue style cuts.
-   - **Not in `report-engine` today:** `CT_REPORT_DIMENSIONS` is exactly **`none` · `status` · `mode` · `lane` · `carrier` · `customer` · `supplier` · `origin` · `destination` · `month`** (`report-engine.ts`) — no **exception code / type** dimension, no **open-exception rate** or **shipments-with-open-exception** measure in `CT_REPORT_MEASURES`.
-   - **Next smallest slice:** add **`exceptionCode`** (catalog label join) as a **dimension** *or* one aggregate measure (**open exception count** / **shipments with open exception**), plus optional **report filter** mirroring workbench `exceptionCode` — before unstructured **rootCause** / external NC codes (better for export + AI insight unless normalized).
+   - **Now in `report-engine`:** `CT_REPORT_DIMENSIONS` includes **`exceptionCatalog`** and `CT_REPORT_MEASURES` includes **`openExceptions`** (`report-engine.ts`), with catalog label mapping in report rows.
+   - **Now in report filters:** builder + run config support **`filters.exceptionCode`** (case-insensitive OPEN / IN_PROGRESS match), so operators can scope any report to a specific exception type.
+   - **Next smallest slice:** add one rate-style metric (e.g. **shipments with open exception %**) and optional grouped trends (e.g. exception by lane/month) before unstructured **rootCause** / external NC codes.
 
 ---
 
@@ -157,6 +158,7 @@ File **one GitHub issue per bullet** when scheduling (titles are suggestions; ke
 
 | Date | Change |
 |------|--------|
+| 2026-04-20 | **Reporting phase 2:** report builder + engine now accept **`filters.exceptionCode`** (case-insensitive open/in-progress filter), and backlog **#7** reflects that exception analytics are live (`exceptionCatalog` + `openExceptions`). |
 | 2026-04-20 | Near-term **4–7** re-checked against code (`report-engine` dimensions, `report-pdf` org line, workbench single-select); tightened Done/Partial/Next; **Suggested next PRs** aligned to **#4–7**; tracking [issue #3](https://github.com/lasealco/po-management/issues/3). |
 | 2026-04-20 | **R3 Assist / chatbot:** gap narrative + **spec parity checklist** vs **`control_tower_search_and_chatbot_spec_*.pdf`** (rows + dedicated subsection); [issue #6](https://github.com/lasealco/po-management/issues/6). |
 | 2026-04-18 | Backlog **#7 (low priority)**: report builder exception / NC-style analytics (deferred; workbench + 360 already cover triage). |

--- a/src/components/control-tower-report-builder.tsx
+++ b/src/components/control-tower-report-builder.tsx
@@ -49,6 +49,7 @@ type ReportConfig = {
     supplierId: string;
     origin: string;
     destination: string;
+    exceptionCode: string;
     onlyOpenExceptions: boolean;
   };
 };
@@ -136,6 +137,7 @@ const DEFAULT_CONFIG: ReportConfig = {
     supplierId: "",
     origin: "",
     destination: "",
+    exceptionCode: "",
     onlyOpenExceptions: false,
   },
 };
@@ -175,6 +177,7 @@ function hydrateConfig(input: unknown): ReportConfig {
       supplierId: typeof filters.supplierId === "string" ? filters.supplierId : "",
       origin: typeof filters.origin === "string" ? filters.origin : "",
       destination: typeof filters.destination === "string" ? filters.destination : "",
+      exceptionCode: typeof filters.exceptionCode === "string" ? filters.exceptionCode : "",
       onlyOpenExceptions: filters.onlyOpenExceptions === true,
     },
   };
@@ -219,6 +222,7 @@ function toRunPayload(config: ReportConfig) {
       supplierId: f.supplierId.trim() || null,
       origin: f.origin.trim() || null,
       destination: f.destination.trim() || null,
+      exceptionCode: f.exceptionCode.trim() || null,
       ...(f.onlyOpenExceptions ? { onlyOpenExceptions: true as const } : {}),
     },
   };
@@ -1206,7 +1210,7 @@ export function ControlTowerReportBuilder({
               </label>
             </div>
 
-            <div className="mt-3 grid gap-3 md:grid-cols-4">
+            <div className="mt-3 grid gap-3 md:grid-cols-5">
               <label className="text-xs text-zinc-700">
                 Status
                 <input
@@ -1234,6 +1238,17 @@ export function ControlTowerReportBuilder({
                   onChange={(e) =>
                     setConfig((c) => ({ ...c, filters: { ...c.filters, lane: e.target.value } }))
                   }
+                  className="mt-1 w-full rounded border border-zinc-300 px-2 py-1.5 text-sm"
+                />
+              </label>
+              <label className="text-xs text-zinc-700">
+                Exception code
+                <input
+                  value={config.filters.exceptionCode}
+                  onChange={(e) =>
+                    setConfig((c) => ({ ...c, filters: { ...c.filters, exceptionCode: e.target.value } }))
+                  }
+                  placeholder="e.g. LATE_DOC"
                   className="mt-1 w-full rounded border border-zinc-300 px-2 py-1.5 text-sm"
                 />
               </label>

--- a/src/lib/control-tower/report-engine-config.test.ts
+++ b/src/lib/control-tower/report-engine-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeCtReportConfig } from "./report-engine";
+
+describe("sanitizeCtReportConfig", () => {
+  it("keeps exceptionCode filter when provided", () => {
+    const config = sanitizeCtReportConfig({
+      filters: { exceptionCode: "LATE_DOC" },
+    });
+    expect(config.filters?.exceptionCode).toBe("LATE_DOC");
+  });
+
+  it("forces openExceptions measure for exceptionCatalog dimension", () => {
+    const config = sanitizeCtReportConfig({
+      dimension: "exceptionCatalog",
+      measure: "shipments",
+    });
+    expect(config.measure).toBe("openExceptions");
+  });
+});

--- a/src/lib/control-tower/report-engine.ts
+++ b/src/lib/control-tower/report-engine.ts
@@ -69,6 +69,7 @@ export type CtReportConfig = {
     supplierId?: string | null;
     origin?: string | null;
     destination?: string | null;
+    exceptionCode?: string | null;
     onlyOpenExceptions?: boolean;
   };
   topN?: number;
@@ -198,6 +199,7 @@ export function sanitizeCtReportConfig(input: unknown): CtReportConfig {
       supplierId: typeof filtersObj.supplierId === "string" ? filtersObj.supplierId : null,
       origin: typeof filtersObj.origin === "string" ? filtersObj.origin : null,
       destination: typeof filtersObj.destination === "string" ? filtersObj.destination : null,
+      exceptionCode: typeof filtersObj.exceptionCode === "string" ? filtersObj.exceptionCode : null,
       onlyOpenExceptions: filtersObj.onlyOpenExceptions === true,
     },
   };
@@ -320,6 +322,16 @@ export async function runControlTowerReport(params: {
   if (nonEmpty(filters.supplierId)) ands.push({ order: { supplierId: filters.supplierId!.trim() } });
   if (nonEmpty(filters.origin)) ands.push({ booking: { is: { originCode: { contains: filters.origin!.trim(), mode: "insensitive" } } } });
   if (nonEmpty(filters.destination)) ands.push({ booking: { is: { destinationCode: { contains: filters.destination!.trim(), mode: "insensitive" } } } });
+  if (nonEmpty(filters.exceptionCode)) {
+    ands.push({
+      ctExceptions: {
+        some: {
+          status: { in: [CtExceptionStatus.OPEN, CtExceptionStatus.IN_PROGRESS] },
+          type: { equals: filters.exceptionCode!.trim(), mode: "insensitive" },
+        },
+      },
+    });
+  }
   if (nonEmpty(filters.lane)) {
     const lane = filters.lane!.trim();
     ands.push({


### PR DESCRIPTION
## Summary
- add `filters.exceptionCode` to the Control Tower report config pipeline (builder payload -> report-engine sanitize/query) so runs can target a specific open/in-progress exception type
- add focused report-engine config tests for exception filter retention and `exceptionCatalog` measure forcing
- update `docs/controltower/GAP_MAP.md` backlog #7 to reflect shipped exception analytics and new report filter support

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`

Made with [Cursor](https://cursor.com)