### PR TITLE
fix(sales-orders): tighten PATCH/GET error handling

### DIFF
--- a/src/app/api/sales-orders/[id]/route.ts
+++ b/src/app/api/sales-orders/[id]/route.ts
@@ -3,6 +3,11 @@ import { NextResponse } from "next/server";
 import { requireApiGrant } from "@/lib/authz";
 import { getDemoTenant } from "@/lib/demo-tenant";
 import { prisma } from "@/lib/prisma";
+import {
+  canTransitionSalesOrderStatus,
+  parseSalesOrderPatchPayload,
+  type SalesOrderStatus,
+} from "@/lib/sales-orders";
 
 export async function GET(
   _request: Request,
@@ -14,6 +19,8 @@ export async function GET(
   const tenant = await getDemoTenant();
   if (!tenant) return NextResponse.json({ error: "Tenant not found." }, { status: 404 });
   const { id } = await context.params;
+
+  if (!id) return NextResponse.json({ error: "Sales order id is required." }, { status: 400 });
 
   const row = await prisma.salesOrder.findFirst({
     where: { id, tenantId: tenant.id },
@@ -31,7 +38,10 @@ export async function GET(
         },
       },
     },
-  });
+  }).catch(() => undefined);
+  if (row === undefined) {
+    return NextResponse.json({ error: "Could not load sales order." }, { status: 500 });
+  }
   if (!row) return NextResponse.json({ error: "Sales order not found." }, { status: 404 });
 
   return NextResponse.json({
@@ -56,6 +66,7 @@ export async function PATCH(
   const tenant = await getDemoTenant();
   if (!tenant) return NextResponse.json({ error: "Tenant not found." }, { status: 404 });
   const { id } = await context.params;
+  if (!id) return NextResponse.json({ error: "Sales order id is required." }, { status: 400 });
 
   let body: unknown = {};
   try {
@@ -63,10 +74,9 @@ export async function PATCH(
   } catch {
     return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
   }
-  const o = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
-  const targetStatus = typeof o.status === "string" ? o.status.trim().toUpperCase() : "";
-  if (!["DRAFT", "OPEN", "CLOSED"].includes(targetStatus)) {
-    return NextResponse.json({ error: "status must be DRAFT | OPEN | CLOSED" }, { status: 400 });
+  const parsed = parseSalesOrderPatchPayload(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
   }
 
   const row = await prisma.salesOrder.findFirst({
@@ -76,20 +86,16 @@ export async function PATCH(
       status: true,
       shipments: { select: { id: true, status: true, shipmentNo: true } },
     },
-  });
+  }).catch(() => undefined);
+  if (row === undefined) {
+    return NextResponse.json({ error: "Could not load sales order." }, { status: 500 });
+  }
   if (!row) return NextResponse.json({ error: "Sales order not found." }, { status: 404 });
 
-  const current = row.status;
-  const allowed: Record<string, string[]> = {
-    DRAFT: ["OPEN", "CLOSED"],
-    OPEN: ["DRAFT", "CLOSED"],
-    CLOSED: ["OPEN"],
-  };
-  if (!allowed[current]?.includes(targetStatus)) {
-    return NextResponse.json(
-      { error: `Cannot change status from ${current} to ${targetStatus}.` },
-      { status: 409 },
-    );
+  const targetStatus = parsed.status;
+  const transition = canTransitionSalesOrderStatus(row.status as SalesOrderStatus, targetStatus);
+  if (!transition.ok) {
+    return NextResponse.json({ error: transition.error }, { status: 409 });
   }
 
   if (targetStatus === "CLOSED") {
@@ -111,9 +117,13 @@ export async function PATCH(
 
   const updated = await prisma.salesOrder.update({
     where: { id: row.id },
-    data: { status: targetStatus as "DRAFT" | "OPEN" | "CLOSED" },
+    data: { status: targetStatus },
     select: { id: true, status: true },
-  });
+  }).catch(() => null);
+
+  if (!updated) {
+    return NextResponse.json({ error: "Could not update sales order status." }, { status: 500 });
+  }
 
   return NextResponse.json({ ok: true, id: updated.id, status: updated.status });
 }

--- a/src/lib/sales-orders/index.ts
+++ b/src/lib/sales-orders/index.ts
@@ -1,4 +1,5 @@
 export type { SalesOrdersListQuery } from "./list-filters";
+export type { SalesOrderStatus } from "./status-transition";
 export {
   buildSalesOrdersListSearch,
   nextSearchParamsToURLSearchParams,
@@ -9,3 +10,4 @@ export {
   salesOrdersListQueryString,
 } from "./list-filters";
 export { nextSalesOrderNumber } from "./next-number";
+export { canTransitionSalesOrderStatus, parseSalesOrderPatchPayload, SALES_ORDER_STATUSES } from "./status-transition";

--- a/src/lib/sales-orders/status-transition.test.ts
+++ b/src/lib/sales-orders/status-transition.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { canTransitionSalesOrderStatus, parseSalesOrderPatchPayload } from "./status-transition";
+
+describe("parseSalesOrderPatchPayload", () => {
+  it("accepts valid status with case and spaces", () => {
+    expect(parseSalesOrderPatchPayload({ status: "  open " })).toEqual({ ok: true, status: "OPEN" });
+  });
+
+  it("rejects non-object payloads", () => {
+    expect(parseSalesOrderPatchPayload(null)).toEqual({
+      ok: false,
+      error: "Request body must be a JSON object.",
+    });
+    expect(parseSalesOrderPatchPayload(["OPEN"])).toEqual({
+      ok: false,
+      error: "Request body must be a JSON object.",
+    });
+  });
+
+  it("rejects missing status", () => {
+    expect(parseSalesOrderPatchPayload({})).toEqual({ ok: false, error: "status is required." });
+  });
+
+  it("rejects unsupported status", () => {
+    expect(parseSalesOrderPatchPayload({ status: "cancelled" })).toEqual({
+      ok: false,
+      error: "status must be DRAFT | OPEN | CLOSED",
+    });
+  });
+});
+
+describe("canTransitionSalesOrderStatus", () => {
+  it("rejects no-op transitions", () => {
+    expect(canTransitionSalesOrderStatus("OPEN", "OPEN")).toEqual({
+      ok: false,
+      error: "Sales order is already OPEN.",
+    });
+  });
+
+  it("allows valid transitions", () => {
+    expect(canTransitionSalesOrderStatus("DRAFT", "OPEN")).toEqual({ ok: true });
+    expect(canTransitionSalesOrderStatus("OPEN", "CLOSED")).toEqual({ ok: true });
+    expect(canTransitionSalesOrderStatus("CLOSED", "OPEN")).toEqual({ ok: true });
+  });
+});

--- a/src/lib/sales-orders/status-transition.ts
+++ b/src/lib/sales-orders/status-transition.ts
@@ -1,0 +1,51 @@
+export const SALES_ORDER_STATUSES = ["DRAFT", "OPEN", "CLOSED"] as const;
+
+export type SalesOrderStatus = (typeof SALES_ORDER_STATUSES)[number];
+
+type PatchPayloadError = { ok: false; error: string };
+
+type PatchPayloadSuccess = { ok: true; status: SalesOrderStatus };
+
+export type ParseSalesOrderPatchPayloadResult = PatchPayloadError | PatchPayloadSuccess;
+
+const ALLOWED_TRANSITIONS: Record<SalesOrderStatus, readonly SalesOrderStatus[]> = {
+  DRAFT: ["OPEN", "CLOSED"],
+  OPEN: ["DRAFT", "CLOSED"],
+  CLOSED: ["OPEN"],
+};
+
+export function parseSalesOrderPatchPayload(body: unknown): ParseSalesOrderPatchPayloadResult {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "Request body must be a JSON object." };
+  }
+
+  const payload = body as Record<string, unknown>;
+  const status = typeof payload.status === "string" ? payload.status.trim().toUpperCase() : "";
+  if (!status) {
+    return { ok: false, error: "status is required." };
+  }
+  if (!isSalesOrderStatus(status)) {
+    return { ok: false, error: "status must be DRAFT | OPEN | CLOSED" };
+  }
+
+  return { ok: true, status };
+}
+
+export function canTransitionSalesOrderStatus(
+  current: SalesOrderStatus,
+  target: SalesOrderStatus,
+): { ok: true } | { ok: false; error: string } {
+  if (current === target) {
+    return { ok: false, error: `Sales order is already ${current}.` };
+  }
+
+  if (!ALLOWED_TRANSITIONS[current].includes(target)) {
+    return { ok: false, error: `Cannot change status from ${current} to ${target}.` };
+  }
+
+  return { ok: true };
+}
+
+function isSalesOrderStatus(value: string): value is SalesOrderStatus {
+  return (SALES_ORDER_STATUSES as readonly string[]).includes(value);
+}


### PR DESCRIPTION
## Summary
- extract sales-order PATCH payload parsing and status-transition validation into `src/lib/sales-orders/status-transition.ts`
- add focused unit tests for payload validation and transition rules in `src/lib/sales-orders/status-transition.test.ts`
- harden `GET/PATCH /api/sales-orders/[id]` with predictable JSON errors for missing id, invalid payloads, DB lookup/update failures, and transition/no-op conflicts

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`

Made with [Cursor](https://cursor.com)