### PR TITLE
test(tariff): promote import edge cases and API error parity

### DIFF
--- a/src/app/api/tariffs/import-batches/_lib/promote-import-body.test.ts
+++ b/src/app/api/tariffs/import-batches/_lib/promote-import-body.test.ts
@@ -36,10 +36,10 @@ describe("parsePromoteImportRequestBody", () => {
     });
   });
 
-  it("treats array bodies like empty objects (no string id)", () => {
+  it("rejects array bodies as invalid payload shape", () => {
     expect(parsePromoteImportRequestBody([])).toEqual({
       ok: false,
-      error: "contractHeaderId is required.",
+      error: "Expected object body.",
     });
   });
 });

--- a/src/app/api/tariffs/import-batches/_lib/promote-import-body.ts
+++ b/src/app/api/tariffs/import-batches/_lib/promote-import-body.ts
@@ -3,7 +3,7 @@ export type ParsePromoteImportBodyResult =
   | { ok: false; error: string };
 
 export function parsePromoteImportRequestBody(body: unknown): ParsePromoteImportBodyResult {
-  if (!body || typeof body !== "object") {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
     return { ok: false, error: "Expected object body." };
   }
   const contractHeaderId =

--- a/src/lib/tariff/promote-staging-import.test.ts
+++ b/src/lib/tariff/promote-staging-import.test.ts
@@ -6,17 +6,24 @@ describe("promoteStagingImportAmountPresent", () => {
   it("treats numeric zero and string zero as present", () => {
     expect(promoteStagingImportAmountPresent(0)).toBe(true);
     expect(promoteStagingImportAmountPresent("0")).toBe(true);
+    expect(promoteStagingImportAmountPresent("  0  ")).toBe(true);
   });
 
-  it("accepts finite numbers and non-empty strings", () => {
+  it("accepts finite numbers and numeric strings", () => {
     expect(promoteStagingImportAmountPresent(1250.5)).toBe(true);
     expect(promoteStagingImportAmountPresent("  99  ")).toBe(true);
+    expect(promoteStagingImportAmountPresent("-12.35")).toBe(true);
+    expect(promoteStagingImportAmountPresent("1e3")).toBe(true);
   });
 
-  it("rejects blank strings, NaN, null, undefined, and objects", () => {
+  it("rejects blank and non-numeric strings, NaN/infinite values, null, undefined, and objects", () => {
     expect(promoteStagingImportAmountPresent("")).toBe(false);
     expect(promoteStagingImportAmountPresent("   ")).toBe(false);
+    expect(promoteStagingImportAmountPresent("abc")).toBe(false);
+    expect(promoteStagingImportAmountPresent("12,000")).toBe(false);
     expect(promoteStagingImportAmountPresent(Number.NaN)).toBe(false);
+    expect(promoteStagingImportAmountPresent(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(promoteStagingImportAmountPresent(Number.NEGATIVE_INFINITY)).toBe(false);
     expect(promoteStagingImportAmountPresent(null)).toBe(false);
     expect(promoteStagingImportAmountPresent(undefined)).toBe(false);
     expect(promoteStagingImportAmountPresent({})).toBe(false);

--- a/src/lib/tariff/promote-staging-import.ts
+++ b/src/lib/tariff/promote-staging-import.ts
@@ -36,7 +36,11 @@ function pickOptionalString(o: Record<string, unknown>, key: string): string | n
 export function promoteStagingImportAmountPresent(amount: unknown): boolean {
   if (amount === 0 || amount === "0") return true;
   if (typeof amount === "number") return Number.isFinite(amount);
-  if (typeof amount === "string") return amount.trim().length > 0;
+  if (typeof amount === "string") {
+    const normalized = amount.trim();
+    if (!normalized) return false;
+    return Number.isFinite(Number(normalized));
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Harden promote import amount validation by rejecting non-numeric string amounts before rate/charge creation.
- Tighten promote request body parsing to reject array payloads as invalid object bodies.
- Extend tariff promote tests to cover numeric-string edge cases and API body-shape parity.

## Test plan
- [x] npm run test
- [ ] npm run lint
- [ ] npx tsc --noEmit
- [ ] npm run verify:tariff-engine


Made with [Cursor](https://cursor.com)