### PR TITLE
feat(srm): map permissions matrix to SRM route behavior

### DIFF
--- a/docs/engineering/agent-todos/srm.md
+++ b/docs/engineering/agent-todos/srm.md
@@ -30,3 +30,4 @@ Routes exist: `/srm`, `/srm/new`, `/srm/[id]`, supplier links from suppliers hub
 - [ ] Link each merged PR to a line in `docs/srm/GAP_MAP.md` once it exists.
 - [x] SRM gap baseline: [`docs/srm/GAP_MAP.md`](../../srm/GAP_MAP.md)
 - [x] Issue #13 (`[srm] Meeting batch (~2h): GAP_MAP + list search UX + tests`) maps to `docs/srm/GAP_MAP.md` sections: "Routes and authorization", "Supplier and list/detail usage", and near-term build order item 2.
+- [x] SRM permissions matrix slice: shared SRM permission resolver + list/detail order-metrics gating (`org.orders` → view), documented in `docs/srm/GAP_MAP.md` routes/permissions rows.

--- a/docs/srm/GAP_MAP.md
+++ b/docs/srm/GAP_MAP.md
@@ -12,7 +12,7 @@
 
 | Surface | Path | Grants (typical) | Notes |
 |---------|------|------------------|--------|
-| SRM partner list | `/srm` | `org.suppliers` → **view** | Query: `kind=` (`product` \| `logistics`, default product), **`q=`** search on name / code / email (case-insensitive contains). |
+| SRM partner list | `/srm` | `org.suppliers` → **view** | Query: `kind=` (`product` \| `logistics`, default product), **`q=`** search on name / code / email (case-insensitive contains). Order count column is visible only with `org.orders` → **view**. |
 | Create partner | `/srm/new` | `org.suppliers` → **edit** | `kind=` selects default `srmCategory` on create. |
 | Supplier 360 | `/srm/[id]` | `org.suppliers` → **view**; **edit** / **approve** for mutations | Uses `loadSupplierDetailSnapshot`; order analytics if `org.orders` → view. |
 | Legacy directory | `/suppliers`, `/suppliers/[id]` | Same grants | Alternate list/detail chrome; not deprecated in code. |
@@ -28,7 +28,7 @@
 | `srm_data_model_and_er_spec_20260417_063215.pdf` | Data model / ER | 🟡 | `Supplier`, `SupplierOffice`, `SupplierContact`, `SupplierServiceCapability`, links to PO / bookings / CT as in Prisma; not every ER relationship exposed in UI. |
 | `srm_supplier_lifecycle_and_onboarding_spec_20260417_063215.pdf` | Lifecycle & onboarding | 🟡 | `approvalStatus`, activation, buyer create path; full staged onboarding / portal flows ❌. |
 | `srm_workflow_and_business_rules_20260417_063215.pdf` | Workflows & rules | 🟡 | Approval + category split; deep workflow engine / rule builder ❌. |
-| `srm_permission_and_visibility_matrix_20260417_063215.pdf` | Permissions matrix | 🟡 | `org.suppliers` view / edit / approve (+ orders view for history); field-level matrix ❌. |
+| `srm_permission_and_visibility_matrix_20260417_063215.pdf` | Permissions matrix | 🟡 | `org.suppliers` view / edit / approve mapped through shared SRM permission resolver; order metrics/history gated by `org.orders` view. Field-level matrix ❌. |
 | `srm_ux_ui_design_guideline_and_wireframe_pack_20260417_063215.pdf` | UX / wireframes | 🟡 | Workflow headers, tables, 360 client; pixel parity with pack ❌. |
 | `srm_compliance_and_document_control_spec_20260417_063215.pdf` | Compliance & doc control | ❌ | No dedicated document-control vault for SRM yet. |
 | `srm_performance_risk_and_kpi_spec_20260417_063215.pdf` | Performance / KPI | ❌ | No SRM KPI dashboard slice yet. |
@@ -55,10 +55,10 @@ Numbered for engineering slices; refresh when shipped behavior changes.
 1. **Hygiene & planning** — Keep this `GAP_MAP` current; link each merged SRM slice PR to the relevant row (see `docs/engineering/agent-todos/srm.md`).
 2. **Operator list quality** — **Done in meeting batch:** URL **`q=`** search + no-results state on `/srm` (server-side filter, `kind=` preserved).
 3. **Lifecycle / onboarding** — Next steps from `srm_supplier_lifecycle_and_onboarding_spec` (tasks, notifications, staged data capture) as separate issues.
-4. **Permissions depth** — Map `srm_permission_and_visibility_matrix` to `org.*` grants and API guards incrementally.
+4. **Permissions depth** — In progress: shared SRM grant resolver now gates list/detail and hides order metrics unless `org.orders` → view. Continue with API and field-level guards.
 5. **Compliance & documents** — Read-only hooks or attachments from `srm_compliance_and_document_control_spec` before write-heavy vault.
 6. **KPI / risk** — One chart or table from `srm_performance_risk_and_kpi_spec` (supplier health, concentration, SLA) scoped to demo data.
 7. **Integration pack** — One payload type + tests from `srm_integration_and_api_payload_pack` (inbound or outbound).
 8. **Workflow rules** — Explicit validations / transitions from `srm_workflow_and_business_rules` where they exceed today's approval + active flags.
 
-_Last updated: SRM list search (`?q=`), GAP_MAP introduction._
+_Last updated: SRM permissions slice (shared resolver + order-metrics visibility), SRM list search (`?q=`), GAP_MAP introduction._

--- a/src/app/srm/[id]/page.tsx
+++ b/src/app/srm/[id]/page.tsx
@@ -3,8 +3,9 @@ import { notFound } from "next/navigation";
 import { AccessDenied } from "@/components/access-denied";
 import { SupplierDetailClient } from "@/components/supplier-detail-client";
 import { WorkflowHeader } from "@/components/workflow-header";
-import { getViewerGrantSet, viewerHas } from "@/lib/authz";
+import { getViewerGrantSet } from "@/lib/authz";
 import { loadSupplierDetailSnapshot } from "@/lib/srm/load-supplier-detail-snapshot";
+import { resolveSrmPermissions } from "@/lib/srm/permissions";
 import { fetchSupplierOrderAnalytics } from "@/lib/supplier-order-analytics";
 import { prisma } from "@/lib/prisma";
 
@@ -30,7 +31,9 @@ export default async function SrmSupplierDetailPage({
     );
   }
 
-  if (!viewerHas(access.grantSet, "org.suppliers", "view")) {
+  const permissions = resolveSrmPermissions(access.grantSet);
+
+  if (!permissions.canViewSuppliers) {
     return (
       <div className="min-h-screen bg-zinc-50 px-6 py-16">
         <AccessDenied
@@ -46,9 +49,9 @@ export default async function SrmSupplierDetailPage({
   if (!snapshot) notFound();
 
   const kind = snapshot.srmCategory === "logistics" ? "logistics" : "product";
-  const canEdit = viewerHas(access.grantSet, "org.suppliers", "edit");
-  const canApprove = viewerHas(access.grantSet, "org.suppliers", "approve");
-  const canViewOrders = viewerHas(access.grantSet, "org.orders", "view");
+  const canEdit = permissions.canEditSuppliers;
+  const canApprove = permissions.canApproveSuppliers;
+  const canViewOrders = permissions.canViewOrders;
   const orderHistory = canViewOrders
     ? await fetchSupplierOrderAnalytics(prisma, tenant.id, snapshot.id)
     : null;

--- a/src/app/srm/new/page.tsx
+++ b/src/app/srm/new/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 
 import { AccessDenied } from "@/components/access-denied";
 import { SupplierCreateForm } from "@/components/supplier-create-form";
-import { getViewerGrantSet, viewerHas } from "@/lib/authz";
+import { getViewerGrantSet } from "@/lib/authz";
+import { resolveSrmPermissions } from "@/lib/srm/permissions";
 
 export const dynamic = "force-dynamic";
 
@@ -31,7 +32,9 @@ export default async function SrmNewSupplierPage({
     );
   }
 
-  if (!viewerHas(access.grantSet, "org.suppliers", "edit")) {
+  const permissions = resolveSrmPermissions(access.grantSet);
+
+  if (!permissions.canEditSuppliers) {
     return (
       <div className="min-h-screen bg-zinc-50 px-6 py-16">
         <AccessDenied

--- a/src/app/srm/page.tsx
+++ b/src/app/srm/page.tsx
@@ -4,9 +4,10 @@ import { ActionLink } from "@/components/action-button";
 import { AccessDenied } from "@/components/access-denied";
 import { SupplierKindTabs } from "@/components/supplier-kind-tabs";
 import { WorkflowHeader } from "@/components/workflow-header";
-import { getViewerGrantSet, viewerHas } from "@/lib/authz";
+import { getViewerGrantSet } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { parseSrmListQuery } from "@/lib/srm/list-query";
+import { resolveSrmPermissions } from "@/lib/srm/permissions";
 
 export const dynamic = "force-dynamic";
 
@@ -39,7 +40,9 @@ export default async function SrmPage({
     );
   }
 
-  if (!viewerHas(access.grantSet, "org.suppliers", "view")) {
+  const permissions = resolveSrmPermissions(access.grantSet);
+
+  if (!permissions.canViewSuppliers) {
     return (
       <div className="min-h-screen bg-zinc-50 px-6 py-16">
         <AccessDenied
@@ -76,7 +79,7 @@ export default async function SrmPage({
       isActive: true,
       srmCategory: true,
       approvalStatus: true,
-      _count: { select: { orders: true } },
+      ...(permissions.canViewOrders ? { _count: { select: { orders: true } } } : {}),
     },
   });
 
@@ -87,7 +90,7 @@ export default async function SrmPage({
     email: s.email,
     phone: s.phone,
     isActive: s.isActive,
-    orderCount: s._count.orders,
+    orderCount: permissions.canViewOrders && "_count" in s ? s._count.orders : null,
     srmCategory: s.srmCategory === "logistics" ? "logistics" as const : "product" as const,
     approvalStatus:
       s.approvalStatus === "pending_approval"
@@ -97,8 +100,9 @@ export default async function SrmPage({
           : ("approved" as const),
   }));
 
-  const canEdit = viewerHas(access.grantSet, "org.suppliers", "edit");
-  const canApprove = viewerHas(access.grantSet, "org.suppliers", "approve");
+  const canEdit = permissions.canEditSuppliers;
+  const canApprove = permissions.canApproveSuppliers;
+  const canViewOrders = permissions.canViewOrders;
 
   return (
     <div className="min-h-screen bg-zinc-50">
@@ -157,7 +161,7 @@ export default async function SrmPage({
                     <th className="px-4 py-3">Contact</th>
                     <th className="px-4 py-3">Approval</th>
                     <th className="px-4 py-3">Status</th>
-                    <th className="px-4 py-3 text-center">Orders</th>
+                    {canViewOrders ? <th className="px-4 py-3 text-center">Orders</th> : null}
                     <th className="px-4 py-3" />
                   </tr>
                 </thead>
@@ -195,7 +199,7 @@ export default async function SrmPage({
                           {s.isActive ? "Active" : "Inactive"}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-center tabular-nums">{s.orderCount}</td>
+                      {canViewOrders ? <td className="px-4 py-3 text-center tabular-nums">{s.orderCount}</td> : null}
                       <td className="px-4 py-3">
                         <Link href={`/srm/${s.id}`} className="font-medium text-[var(--arscmp-primary)] hover:underline">
                           {canEdit || canApprove ? "Open profile" : "View profile"}
@@ -219,7 +223,10 @@ export default async function SrmPage({
             </section>
           )}
 
-          {!canEdit ? <p className="mt-8 text-sm text-zinc-500">View-only for your role.</p> : null}
+          {!canViewOrders ? (
+            <p className="mt-6 text-sm text-zinc-500">Order metrics are hidden for your role (requires org.orders → view).</p>
+          ) : null}
+          {!canEdit ? <p className="mt-2 text-sm text-zinc-500">View-only for your role.</p> : null}
         </div>
       </main>
     </div>

--- a/src/lib/srm/permissions.test.ts
+++ b/src/lib/srm/permissions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSrmPermissions } from "./permissions";
+
+describe("resolveSrmPermissions", () => {
+  it("returns all SRM permissions as false by default", () => {
+    expect(resolveSrmPermissions(new Set())).toEqual({
+      canViewSuppliers: false,
+      canEditSuppliers: false,
+      canApproveSuppliers: false,
+      canViewOrders: false,
+    });
+  });
+
+  it("allows order metrics only when supplier view is present", () => {
+    expect(resolveSrmPermissions(new Set(["org.orders\u0000view"]))).toEqual({
+      canViewSuppliers: false,
+      canEditSuppliers: false,
+      canApproveSuppliers: false,
+      canViewOrders: false,
+    });
+  });
+
+  it("maps supplier and order grants for SRM pages", () => {
+    expect(
+      resolveSrmPermissions(
+        new Set([
+          "org.suppliers\u0000view",
+          "org.suppliers\u0000edit",
+          "org.suppliers\u0000approve",
+          "org.orders\u0000view",
+        ]),
+      ),
+    ).toEqual({
+      canViewSuppliers: true,
+      canEditSuppliers: true,
+      canApproveSuppliers: true,
+      canViewOrders: true,
+    });
+  });
+});

--- a/src/lib/srm/permissions.ts
+++ b/src/lib/srm/permissions.ts
@@ -1,0 +1,18 @@
+import { viewerHas } from "@/lib/authz";
+
+export type SrmPermissions = {
+  canViewSuppliers: boolean;
+  canEditSuppliers: boolean;
+  canApproveSuppliers: boolean;
+  canViewOrders: boolean;
+};
+
+export function resolveSrmPermissions(grantSet: Set<string>): SrmPermissions {
+  const canViewSuppliers = viewerHas(grantSet, "org.suppliers", "view");
+  return {
+    canViewSuppliers,
+    canEditSuppliers: viewerHas(grantSet, "org.suppliers", "edit"),
+    canApproveSuppliers: viewerHas(grantSet, "org.suppliers", "approve"),
+    canViewOrders: canViewSuppliers && viewerHas(grantSet, "org.orders", "view"),
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared `resolveSrmPermissions` helper in `src/lib/srm` to map SRM route permissions from `org.suppliers` and `org.orders` grants
- update SRM list/new/detail pages to use the shared helper so view/edit/approve checks are consistent
- gate list order metrics behind `org.orders -> view` and document this permissions-matrix slice in SRM docs

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`

Made with [Cursor](https://cursor.com)