### PR TITLE
feat(sales-orders): tighten PATCH /api/sales-orders/[id] errors + tests

### DIFF
--- a/src/app/api/sales-orders/[id]/route.ts
+++ b/src/app/api/sales-orders/[id]/route.ts
@@ -3,6 +3,12 @@ import { NextResponse } from "next/server";
 import { requireApiGrant } from "@/lib/authz";
 import { getDemoTenant } from "@/lib/demo-tenant";
 import { prisma } from "@/lib/prisma";
+import {
+  evaluateSalesOrderStatusTransition,
+  parseSalesOrderPatchRequestBody,
+  parseSalesOrderRouteId,
+  parseTargetSalesOrderStatus,
+} from "@/lib/sales-orders/patch-status";
 
 export async function GET(
   _request: Request,
@@ -13,7 +19,12 @@ export async function GET(
 
   const tenant = await getDemoTenant();
   if (!tenant) return NextResponse.json({ error: "Tenant not found." }, { status: 404 });
-  const { id } = await context.params;
+  const { id: rawId } = await context.params;
+  const idParsed = parseSalesOrderRouteId(rawId);
+  if (!idParsed.ok) {
+    return NextResponse.json({ error: idParsed.error }, { status: idParsed.status });
+  }
+  const { id } = idParsed;
 
   const row = await prisma.salesOrder.findFirst({
     where: { id, tenantId: tenant.id },
@@ -44,8 +55,6 @@ export async function GET(
   });
 }
 
-const ACTIVE_SHIPMENT_STATUSES = new Set(["SHIPPED", "VALIDATED", "BOOKED", "IN_TRANSIT"]);
-
 export async function PATCH(
   request: Request,
   context: { params: Promise<{ id: string }> },
@@ -55,19 +64,30 @@ export async function PATCH(
 
   const tenant = await getDemoTenant();
   if (!tenant) return NextResponse.json({ error: "Tenant not found." }, { status: 404 });
-  const { id } = await context.params;
+  const { id: rawId } = await context.params;
+  const idParsed = parseSalesOrderRouteId(rawId);
+  if (!idParsed.ok) {
+    return NextResponse.json({ error: idParsed.error }, { status: idParsed.status });
+  }
+  const { id } = idParsed;
 
-  let body: unknown = {};
+  let body: unknown;
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
   }
-  const o = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
-  const targetStatus = typeof o.status === "string" ? o.status.trim().toUpperCase() : "";
-  if (!["DRAFT", "OPEN", "CLOSED"].includes(targetStatus)) {
-    return NextResponse.json({ error: "status must be DRAFT | OPEN | CLOSED" }, { status: 400 });
+
+  const parsedBody = parseSalesOrderPatchRequestBody(body);
+  if (!parsedBody.ok) {
+    return NextResponse.json({ error: parsedBody.error }, { status: parsedBody.status });
   }
+
+  const parsedStatus = parseTargetSalesOrderStatus(parsedBody.record);
+  if (!parsedStatus.ok) {
+    return NextResponse.json({ error: parsedStatus.error }, { status: 400 });
+  }
+  const targetStatus = parsedStatus.status;
 
   const row = await prisma.salesOrder.findFirst({
     where: { id, tenantId: tenant.id },
@@ -79,39 +99,24 @@ export async function PATCH(
   });
   if (!row) return NextResponse.json({ error: "Sales order not found." }, { status: 404 });
 
-  const current = row.status;
-  const allowed: Record<string, string[]> = {
-    DRAFT: ["OPEN", "CLOSED"],
-    OPEN: ["DRAFT", "CLOSED"],
-    CLOSED: ["OPEN"],
-  };
-  if (!allowed[current]?.includes(targetStatus)) {
-    return NextResponse.json(
-      { error: `Cannot change status from ${current} to ${targetStatus}.` },
-      { status: 409 },
-    );
-  }
-
-  if (targetStatus === "CLOSED") {
-    const active = row.shipments.filter((s) => ACTIVE_SHIPMENT_STATUSES.has(s.status));
-    if (active.length > 0) {
-      return NextResponse.json(
-        {
-          error: "Cannot close sales order while linked shipments are active.",
-          activeShipments: active.map((s) => ({
-            id: s.id,
-            shipmentNo: s.shipmentNo,
-            status: s.status,
-          })),
-        },
-        { status: 409 },
-      );
+  const transition = evaluateSalesOrderStatusTransition({
+    current: row.status,
+    target: targetStatus,
+    shipments: row.shipments,
+  });
+  if (!transition.ok) {
+    const payload: { error: string; activeShipments?: typeof transition.activeShipments } = {
+      error: transition.error,
+    };
+    if (transition.activeShipments) {
+      payload.activeShipments = transition.activeShipments;
     }
+    return NextResponse.json(payload, { status: transition.status });
   }
 
   const updated = await prisma.salesOrder.update({
     where: { id: row.id },
-    data: { status: targetStatus as "DRAFT" | "OPEN" | "CLOSED" },
+    data: { status: targetStatus },
     select: { id: true, status: true },
   });
 

--- a/src/lib/sales-orders/patch-status.test.ts
+++ b/src/lib/sales-orders/patch-status.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateSalesOrderStatusTransition,
+  parseSalesOrderPatchRequestBody,
+  parseSalesOrderRouteId,
+  parseTargetSalesOrderStatus,
+} from "./patch-status";
+
+describe("parseSalesOrderRouteId", () => {
+  it("rejects blank id", () => {
+    expect(parseSalesOrderRouteId("   ")).toEqual({
+      ok: false,
+      status: 400,
+      error: "Sales order id is required.",
+    });
+  });
+
+  it("accepts trimmed id", () => {
+    expect(parseSalesOrderRouteId("  clxyz123  ")).toEqual({ ok: true, id: "clxyz123" });
+  });
+});
+
+describe("parseSalesOrderPatchRequestBody", () => {
+  it("accepts plain objects", () => {
+    const out = parseSalesOrderPatchRequestBody({ status: "OPEN" });
+    expect(out).toEqual({ ok: true, record: { status: "OPEN" } });
+  });
+
+  it("rejects arrays", () => {
+    expect(parseSalesOrderPatchRequestBody([])).toEqual({
+      ok: false,
+      status: 400,
+      error: "Expected JSON object body.",
+    });
+  });
+
+  it("rejects null", () => {
+    expect(parseSalesOrderPatchRequestBody(null)).toEqual({
+      ok: false,
+      status: 400,
+      error: "Expected JSON object body.",
+    });
+  });
+
+  it("rejects string primitives", () => {
+    expect(parseSalesOrderPatchRequestBody("x")).toEqual({
+      ok: false,
+      status: 400,
+      error: "Expected JSON object body.",
+    });
+  });
+
+  it("rejects number primitives", () => {
+    expect(parseSalesOrderPatchRequestBody(1)).toEqual({
+      ok: false,
+      status: 400,
+      error: "Expected JSON object body.",
+    });
+  });
+});
+
+describe("parseTargetSalesOrderStatus", () => {
+  it("requires status", () => {
+    expect(parseTargetSalesOrderStatus({})).toEqual({
+      ok: false,
+      error: "Field `status` is required.",
+    });
+  });
+
+  it("rejects non-string status", () => {
+    expect(parseTargetSalesOrderStatus({ status: 1 })).toEqual({
+      ok: false,
+      error: "Field `status` must be a string (DRAFT, OPEN, or CLOSED).",
+    });
+  });
+
+  it("normalizes case and whitespace", () => {
+    expect(parseTargetSalesOrderStatus({ status: "  open " })).toEqual({ ok: true, status: "OPEN" });
+  });
+
+  it("rejects unknown status", () => {
+    expect(parseTargetSalesOrderStatus({ status: "PENDING" })).toEqual({
+      ok: false,
+      error: "status must be DRAFT, OPEN, or CLOSED.",
+    });
+  });
+});
+
+describe("evaluateSalesOrderStatusTransition", () => {
+  const ship = (
+    id: string,
+    status: string,
+    shipmentNo: string | null = "S-1",
+  ): { id: string; status: string; shipmentNo: string | null } => ({ id, status, shipmentNo });
+
+  it("allows DRAFT to OPEN", () => {
+    expect(
+      evaluateSalesOrderStatusTransition({
+        current: "DRAFT",
+        target: "OPEN",
+        shipments: [],
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("blocks invalid transition", () => {
+    expect(
+      evaluateSalesOrderStatusTransition({
+        current: "DRAFT",
+        target: "DRAFT",
+        shipments: [],
+      }),
+    ).toEqual({
+      ok: false,
+      status: 409,
+      error: "Cannot change status from DRAFT to DRAFT.",
+    });
+  });
+
+  it("blocks CLOSE when an active shipment exists", () => {
+    const r = evaluateSalesOrderStatusTransition({
+      current: "OPEN",
+      target: "CLOSED",
+      shipments: [ship("s1", "IN_TRANSIT")],
+    });
+    expect(r).toEqual({
+      ok: false,
+      status: 409,
+      error: "Cannot close sales order while linked shipments are active.",
+      activeShipments: [{ id: "s1", shipmentNo: "S-1", status: "IN_TRANSIT" }],
+    });
+  });
+
+  it("allows CLOSE when shipments are not active", () => {
+    expect(
+      evaluateSalesOrderStatusTransition({
+        current: "OPEN",
+        target: "CLOSED",
+        shipments: [ship("s1", "CANCELLED")],
+      }),
+    ).toEqual({ ok: true });
+  });
+});

--- a/src/lib/sales-orders/patch-status.ts
+++ b/src/lib/sales-orders/patch-status.ts
@@ -1,0 +1,100 @@
+const ACTIVE_SHIPMENT_STATUSES = new Set(["SHIPPED", "VALIDATED", "BOOKED", "IN_TRANSIT"]);
+
+export type SalesOrderHeaderStatus = "DRAFT" | "OPEN" | "CLOSED";
+
+const SALES_ORDER_STATUSES: readonly SalesOrderHeaderStatus[] = ["DRAFT", "OPEN", "CLOSED"];
+
+function isSalesOrderHeaderStatus(value: string): value is SalesOrderHeaderStatus {
+  return (SALES_ORDER_STATUSES as readonly string[]).includes(value);
+}
+
+export type SalesOrderShipmentForStatusPatch = {
+  id: string;
+  status: string;
+  shipmentNo: string | null;
+};
+
+export function parseSalesOrderRouteId(
+  raw: string,
+): { ok: true; id: string } | { ok: false; status: 400; error: string } {
+  const id = raw.trim();
+  if (!id) {
+    return { ok: false, status: 400, error: "Sales order id is required." };
+  }
+  return { ok: true, id };
+}
+
+export function parseSalesOrderPatchRequestBody(
+  body: unknown,
+): { ok: true; record: Record<string, unknown> } | { ok: false; status: 400; error: string } {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, status: 400, error: "Expected JSON object body." };
+  }
+  return { ok: true, record: body as Record<string, unknown> };
+}
+
+export function parseTargetSalesOrderStatus(
+  record: Record<string, unknown>,
+): { ok: true; status: SalesOrderHeaderStatus } | { ok: false; error: string } {
+  const raw = record.status;
+  if (raw === undefined) {
+    return { ok: false, error: "Field `status` is required." };
+  }
+  if (typeof raw !== "string") {
+    return { ok: false, error: "Field `status` must be a string (DRAFT, OPEN, or CLOSED)." };
+  }
+  const target = raw.trim().toUpperCase();
+  if (!isSalesOrderHeaderStatus(target)) {
+    return { ok: false, error: "status must be DRAFT, OPEN, or CLOSED." };
+  }
+  return { ok: true, status: target };
+}
+
+const ALLOWED_TRANSITIONS: Record<SalesOrderHeaderStatus, SalesOrderHeaderStatus[]> = {
+  DRAFT: ["OPEN", "CLOSED"],
+  OPEN: ["DRAFT", "CLOSED"],
+  CLOSED: ["OPEN"],
+};
+
+export type SalesOrderStatusTransitionResult =
+  | { ok: true }
+  | {
+      ok: false;
+      status: 409;
+      error: string;
+      activeShipments?: Array<{ id: string; shipmentNo: string | null; status: string }>;
+    };
+
+export function evaluateSalesOrderStatusTransition(input: {
+  current: SalesOrderHeaderStatus;
+  target: SalesOrderHeaderStatus;
+  shipments: SalesOrderShipmentForStatusPatch[];
+}): SalesOrderStatusTransitionResult {
+  const { current, target, shipments } = input;
+  const allowed = ALLOWED_TRANSITIONS[current];
+  if (!allowed?.includes(target)) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Cannot change status from ${current} to ${target}.`,
+    };
+  }
+
+  if (target === "CLOSED") {
+    const active = shipments.filter((s) => ACTIVE_SHIPMENT_STATUSES.has(s.status));
+    if (active.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: "Cannot close sales order while linked shipments are active.",
+        activeShipments: active.map((s) => ({
+          id: s.id,
+          shipmentNo: s.shipmentNo,
+          status: s.status,
+        })),
+      };
+    }
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- extract PATCH status parsing and transition checks into `src/lib/sales-orders/patch-status.ts`
- update `GET/PATCH /api/sales-orders/[id]` to reuse shared parsers and return consistent error payloads
- add Vitest coverage for route id parsing, request body/status parsing, and transition conflict responses

## Validation
- `npm run lint && npx tsc --noEmit && npm run test` attempted
- blocked by pre-existing out-of-scope failures in WMS/control-tower files on this branch

Closes #27

Made with [Cursor](https://cursor.com)