### PR TITLE
fix(crm): improve opportunity stage-change validations

### DIFF
--- a/src/app/api/crm/opportunities/[id]/route.ts
+++ b/src/app/api/crm/opportunities/[id]/route.ts
@@ -2,24 +2,15 @@ import type { CrmOpportunityStage } from "@prisma/client";
 import { NextResponse } from "next/server";
 
 import { getActorUserId, requireApiGrant, userHasGlobalGrant } from "@/lib/authz";
+import {
+  buildInvalidStageMessage,
+  isCrmOpportunityStage,
+  validateOpportunityStageChange,
+} from "@/lib/crm/opportunity-stage-change";
 import { getDemoTenant } from "@/lib/demo-tenant";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
-
-const STAGES: CrmOpportunityStage[] = [
-  "IDENTIFIED",
-  "QUALIFIED",
-  "DISCOVERY",
-  "SOLUTION_DESIGN",
-  "PROPOSAL_SUBMITTED",
-  "NEGOTIATION",
-  "VERBAL_AGREEMENT",
-  "WON_IMPLEMENTATION_PENDING",
-  "WON_LIVE",
-  "LOST",
-  "ON_HOLD",
-];
 
 async function loadOpportunity(tenantId: string, oppId: string, actorId: string) {
   const canEditAll = await userHasGlobalGrant(actorId, "org.crm", "edit");
@@ -125,8 +116,12 @@ export async function PATCH(
   const data: Record<string, unknown> = {};
   if (body.name !== undefined) data.name = body.name.trim();
   if (body.stage !== undefined) {
-    if (!STAGES.includes(body.stage)) {
-      return NextResponse.json({ error: "Invalid stage." }, { status: 400 });
+    if (!isCrmOpportunityStage(body.stage)) {
+      return NextResponse.json({ error: buildInvalidStageMessage(body.stage) }, { status: 400 });
+    }
+    const stageValidation = validateOpportunityStageChange(existing.stage, body.stage);
+    if (!stageValidation.ok) {
+      return NextResponse.json({ error: stageValidation.error }, { status: 400 });
     }
     data.stage = body.stage;
   }

--- a/src/lib/crm/opportunity-stage-change.test.ts
+++ b/src/lib/crm/opportunity-stage-change.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInvalidStageMessage,
+  isCrmOpportunityStage,
+  validateOpportunityStageChange,
+} from "./opportunity-stage-change";
+
+describe("isCrmOpportunityStage", () => {
+  it("accepts known stages", () => {
+    expect(isCrmOpportunityStage("IDENTIFIED")).toBe(true);
+    expect(isCrmOpportunityStage("WON_LIVE")).toBe(true);
+  });
+
+  it("rejects unknown stages", () => {
+    expect(isCrmOpportunityStage("INVALID_STAGE")).toBe(false);
+  });
+});
+
+describe("buildInvalidStageMessage", () => {
+  it("includes the bad value and allowed values", () => {
+    const message = buildInvalidStageMessage("BAD_STAGE");
+    expect(message).toContain("BAD_STAGE");
+    expect(message).toContain("IDENTIFIED");
+    expect(message).toContain("ON_HOLD");
+  });
+});
+
+describe("validateOpportunityStageChange", () => {
+  it("allows normal transitions from non-terminal stages", () => {
+    expect(validateOpportunityStageChange("DISCOVERY", "NEGOTIATION")).toEqual({ ok: true });
+  });
+
+  it("allows no-op stage updates", () => {
+    expect(validateOpportunityStageChange("LOST", "LOST")).toEqual({ ok: true });
+  });
+
+  it("allows reopening terminal stages only through ON_HOLD", () => {
+    expect(validateOpportunityStageChange("LOST", "ON_HOLD")).toEqual({ ok: true });
+    expect(validateOpportunityStageChange("WON_LIVE", "ON_HOLD")).toEqual({ ok: true });
+  });
+
+  it("rejects direct transitions away from LOST", () => {
+    expect(validateOpportunityStageChange("LOST", "NEGOTIATION")).toEqual({
+      ok: false,
+      error: "Cannot move an opportunity out of LOST directly. Move it to ON_HOLD first.",
+    });
+  });
+
+  it("rejects direct transitions away from WON_LIVE", () => {
+    expect(validateOpportunityStageChange("WON_LIVE", "QUALIFIED")).toEqual({
+      ok: false,
+      error: "Cannot move an opportunity out of WON_LIVE directly. Move it to ON_HOLD first.",
+    });
+  });
+});

--- a/src/lib/crm/opportunity-stage-change.ts
+++ b/src/lib/crm/opportunity-stage-change.ts
@@ -1,0 +1,57 @@
+import type { CrmOpportunityStage } from "@prisma/client";
+
+export const CRM_OPPORTUNITY_STAGES: readonly CrmOpportunityStage[] = [
+  "IDENTIFIED",
+  "QUALIFIED",
+  "DISCOVERY",
+  "SOLUTION_DESIGN",
+  "PROPOSAL_SUBMITTED",
+  "NEGOTIATION",
+  "VERBAL_AGREEMENT",
+  "WON_IMPLEMENTATION_PENDING",
+  "WON_LIVE",
+  "LOST",
+  "ON_HOLD",
+];
+
+type StageValidationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error: string;
+    };
+
+const CLOSABLE_STAGES = new Set<CrmOpportunityStage>(["WON_LIVE", "LOST"]);
+
+export function isCrmOpportunityStage(value: string): value is CrmOpportunityStage {
+  return CRM_OPPORTUNITY_STAGES.includes(value as CrmOpportunityStage);
+}
+
+export function buildInvalidStageMessage(value: string): string {
+  return `Invalid stage '${value}'. Expected one of: ${CRM_OPPORTUNITY_STAGES.join(", ")}.`;
+}
+
+export function validateOpportunityStageChange(
+  currentStage: CrmOpportunityStage,
+  requestedStage: CrmOpportunityStage,
+): StageValidationResult {
+  if (currentStage === requestedStage) {
+    return { ok: true };
+  }
+
+  if (!CLOSABLE_STAGES.has(currentStage)) {
+    return { ok: true };
+  }
+
+  if (requestedStage === "ON_HOLD") {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    error:
+      currentStage === "WON_LIVE"
+        ? "Cannot move an opportunity out of WON_LIVE directly. Move it to ON_HOLD first."
+        : "Cannot move an opportunity out of LOST directly. Move it to ON_HOLD first.",
+  };
+}


### PR DESCRIPTION
## Summary
- extract CRM opportunity stage-change validation into pure helpers under `src/lib/crm/opportunity-stage-change.ts`
- return clearer stage-related PATCH errors in `src/app/api/crm/opportunities/[id]/route.ts`, including invalid stage values and disallowed direct transitions from terminal stages
- add focused Vitest coverage for the extracted stage helper behavior

## Test plan
- [x] `npm run lint`
- [ ] `npx tsc --noEmit` *(fails in unrelated `src/lib/apihub/connectors-repo.ts` due missing `apiHubConnectorAuditLog` Prisma client property in current workspace state)*
- [x] `npm run test`

Made with [Cursor](https://cursor.com)