### PR TITLE
feat(control-tower): add safe bulk alert acknowledge in workbench

### DIFF
--- a/docs/controltower/GAP_MAP.md
+++ b/docs/controltower/GAP_MAP.md
@@ -85,7 +85,7 @@
 
 Handlers live in `src/lib/control-tower/post-actions.ts` (thin `src/app/api/control-tower/route.ts`).
 
-High-level groups: **references** · **tracking milestones** (+ pack apply) · **notes** · **documents** · **financial snapshots** · **cost lines** · **FX / display currency** · **alerts** · **exceptions** · **booking / forwarder** · **saved filters** · **shipment customer & carrier** · **sales order link / create** · **booking send/confirm** · **demo enrich/timeline** (optional **`shipmentId`**, regenerate + **`demoProfile`**: `delayed` \| `at_risk` \| `on_time`) · **legs** · **containers** · **cargo lines** · **exception code upsert** (catalog).
+High-level groups: **references** · **tracking milestones** (+ pack apply) · **notes** · **documents** · **financial snapshots** · **cost lines** · **FX / display currency** · **alerts** (single + **bulk acknowledge open alerts**) · **exceptions** · **booking / forwarder** · **saved filters** · **shipment customer & carrier** · **sales order link / create** · **booking send/confirm** · **demo enrich/timeline** (optional **`shipmentId`**, regenerate + **`demoProfile`**: `delayed` \| `at_risk` \| `on_time`) · **legs** · **containers** · **cargo lines** · **exception code upsert** (catalog).
 
 *(When adding actions, extend this list in the same PR.)*
 
@@ -133,9 +133,9 @@ Use this list when slicing PRs; refresh it whenever Control Tower behavior or `r
    - **Partial:** layout is still a **single tabular narrative** (`pdf-lib` + Helvetica), not a **logo-driven template pack**, multi-section executive KPI story, or pixel-faithful spec layouts from the PDF.
    - **Next smallest slice:** **raster logo hook** (tenant URL or upload) + typography / spacing tokens on the same PDF builder, reused by schedule + Download PDF — then add sections incrementally instead of a layout engine rewrite.
 6. **Workbench**
-   - **Done:** filters (incl. **open exception code** + **open alert type**), **saved views** (`CtSavedFilter`), **column visibility** (browser `localStorage` + optional **`columnVisibility` on saved view**), CSV export aligned to visible columns + **`# …` cap line** when truncated, **list cap** surfaced in UI, **deep links** from hub + executive + reports → `controlTowerWorkbenchPath` (status, overdue ETA, drills).
-   - **Partial / gap:** no **row multi-select** or **bulk** alert/exception/assign from the grid; no **server-stored default column visibility** per actor outside **`columnVisibility` inside saved-view JSON**.
-   - **Next smallest slice:** **multi-select + one bulk action** (e.g. acknowledge alerts or assign ops owner) with the same tenant scoping as single-row POST actions — **or** **server-stored default column visibility** per actor if ops consistency matters more than throughput.
+   - **Done:** filters (incl. **open exception code** + **open alert type**), **saved views** (`CtSavedFilter`), **column visibility** (browser `localStorage` + optional **`columnVisibility` on saved view**), CSV export aligned to visible columns + **`# …` cap line** when truncated, **list cap** surfaced in UI, **deep links** from hub + executive + reports → `controlTowerWorkbenchPath` (status, overdue ETA, drills), **row multi-select + bulk acknowledge open alerts** (`bulk_acknowledge_ct_alerts`) from the workbench list.
+   - **Partial / gap:** bulk operators remain narrow (alerts acknowledge only today); no bulk exception action or bulk ops-owner assignment yet; no **server-stored default column visibility** per actor outside **`columnVisibility` inside saved-view JSON**.
+   - **Next smallest slice:** add one more scoped bulk operator (`assign_ct_exception_owner` or shipment ops assignee) with the same tenant scoping/audit approach as existing single-row actions — **or** add **server-stored default column visibility** per actor if ops consistency matters more than throughput.
 7. **(Low priority)** **Report builder — exception / “NC” style analytics**
    - **Done elsewhere:** exceptions are first-class in **workbench**, **search**, **Shipment 360**, and **exception catalog** (`CtException` / `CtExceptionCode`); list/search APIs accept **`exceptionCode`** / **`alertType`** for open-queue style cuts.
    - **Now in `report-engine`:** `CT_REPORT_DIMENSIONS` includes **`exceptionCatalog`** and `CT_REPORT_MEASURES` includes **`openExceptions`** (`report-engine.ts`), with catalog label mapping in report rows.
@@ -160,6 +160,7 @@ File **one GitHub issue per bullet** when scheduling (titles are suggestions; ke
 
 | Date | Change |
 |------|--------|
+| 2026-04-20 | **Workbench bulk operator:** added row multi-select and **Acknowledge open alerts** action on `/control-tower/workbench`, backed by `POST /api/control-tower` action **`bulk_acknowledge_ct_alerts`** (tenant-scoped OPEN → ACKNOWLEDGED only, per-alert audit writes). |
 | 2026-04-20 | **Reporting phase 2:** report builder + engine now accept **`filters.exceptionCode`** (case-insensitive open/in-progress filter), and backlog **#7** reflects that exception analytics are live (`exceptionCatalog` + `openExceptions`). |
 | 2026-04-20 | Clarified **R3 Assist / chatbot** parity section as an explicit **docs-only** handoff artifact (no runtime changes) to match [issue #6](https://github.com/lasealco/po-management/issues/6) scope. |
 | 2026-04-20 | Near-term **4–7** re-checked against code (`report-engine` dimensions, `report-pdf` org line, workbench single-select); tightened Done/Partial/Next; **Suggested next PRs** aligned to **#4–7**; tracking [issue #3](https://github.com/lasealco/po-management/issues/3). |

--- a/src/components/control-tower-workbench.tsx
+++ b/src/components/control-tower-workbench.tsx
@@ -329,6 +329,7 @@ function ControlTowerWorkbenchInner({
   /** Client-only slice on the loaded rows; not stored in the URL. */
   const [healthQuickFilter, setHealthQuickFilter] = useState<HealthState | null>(null);
   const [colVis, setColVis] = useState<Record<WorkbenchTogglableColumn, boolean>>(defaultWorkbenchColumnVisibility);
+  const [selectedShipmentIds, setSelectedShipmentIds] = useState<string[]>([]);
 
   useLayoutEffect(() => {
     const patch = parseWorkbenchColumnVisibility(window.localStorage.getItem(WORKBENCH_COLUMN_STORAGE_KEY));
@@ -911,9 +912,27 @@ function ControlTowerWorkbenchInner({
     if (page > totalPages) setPage(totalPages);
   }, [page, totalPages]);
 
+  const canUseBulkAlertAck = canEdit && !restrictedView;
+  useEffect(() => {
+    setSelectedShipmentIds((prev) => {
+      if (prev.length === 0) return prev;
+      const visibleRowIds = new Set(rows.map((r) => r.id));
+      const next = prev.filter((id) => visibleRowIds.has(id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [rows]);
+  const selectedShipmentSet = useMemo(() => new Set(selectedShipmentIds), [selectedShipmentIds]);
+  const selectedEligibleShipmentIds = useMemo(
+    () => rows.filter((r) => selectedShipmentSet.has(r.id) && (r.openQueueCounts?.openAlerts ?? 0) > 0).map((r) => r.id),
+    [rows, selectedShipmentSet],
+  );
+  const pagedRowIds = useMemo(() => pagedRows.map((r) => r.id), [pagedRows]);
+  const allRowsOnPageSelected =
+    pagedRowIds.length > 0 && pagedRowIds.every((shipmentId) => selectedShipmentSet.has(shipmentId));
+
   const tableColSpan = useMemo(
-    () => workbenchVisibleColumnCount(colVis, Boolean(restrictedView)),
-    [colVis, restrictedView],
+    () => workbenchVisibleColumnCount(colVis, Boolean(restrictedView)) + (canUseBulkAlertAck ? 1 : 0),
+    [canUseBulkAlertAck, colVis, restrictedView],
   );
 
   const setExternalOrderRef = useCallback(
@@ -1554,11 +1573,86 @@ function ControlTowerWorkbenchInner({
           </button>
         </div>
       </details>
+      {canUseBulkAlertAck ? (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-700">
+          <button
+            type="button"
+            className="rounded border border-zinc-300 bg-white px-2 py-1 hover:bg-zinc-100"
+            onClick={() => {
+              setSelectedShipmentIds((prev) => {
+                if (allRowsOnPageSelected) {
+                  const pageSet = new Set(pagedRowIds);
+                  return prev.filter((id) => !pageSet.has(id));
+                }
+                const next = new Set(prev);
+                for (const rowId of pagedRowIds) next.add(rowId);
+                return Array.from(next);
+              });
+            }}
+          >
+            {allRowsOnPageSelected ? "Clear page selection" : "Select page"}
+          </button>
+          <button
+            type="button"
+            disabled={selectedEligibleShipmentIds.length === 0}
+            className="rounded border border-arscmp-primary bg-arscmp-primary px-2 py-1 font-medium text-white disabled:cursor-not-allowed disabled:opacity-40"
+            onClick={async () => {
+              const shipmentIds = selectedEligibleShipmentIds;
+              if (shipmentIds.length === 0) {
+                window.alert("Select at least one shipment with open alerts.");
+                return;
+              }
+              const res = await fetch("/api/control-tower", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  action: "bulk_acknowledge_ct_alerts",
+                  shipmentIds,
+                }),
+              });
+              const payload = (await res.json()) as { error?: string; acknowledgedAlertCount?: number };
+              if (!res.ok) {
+                window.alert(payload.error || "Could not acknowledge alerts.");
+                return;
+              }
+              window.alert(`Acknowledged ${payload.acknowledgedAlertCount ?? 0} open alerts.`);
+              setSelectedShipmentIds([]);
+              await load();
+            }}
+          >
+            Acknowledge open alerts
+          </button>
+          <span>
+            Selected shipments: <strong>{selectedShipmentIds.length}</strong> · with open alerts:{" "}
+            <strong>{selectedEligibleShipmentIds.length}</strong>
+          </span>
+        </div>
+      ) : null}
 
       <div className="overflow-x-auto rounded-lg border border-zinc-200 bg-white">
         <table className="min-w-full text-sm">
           <thead className="bg-zinc-100 text-left text-xs font-semibold uppercase text-zinc-800">
             <tr>
+              {canUseBulkAlertAck ? (
+                <th className="w-10 px-2 py-2 text-center">
+                  <input
+                    type="checkbox"
+                    aria-label={allRowsOnPageSelected ? "Clear page selection" : "Select rows on page"}
+                    checked={allRowsOnPageSelected}
+                    onChange={() => {
+                      setSelectedShipmentIds((prev) => {
+                        if (allRowsOnPageSelected) {
+                          const pageSet = new Set(pagedRowIds);
+                          return prev.filter((id) => !pageSet.has(id));
+                        }
+                        const next = new Set(prev);
+                        for (const rowId of pagedRowIds) next.add(rowId);
+                        return Array.from(next);
+                      });
+                    }}
+                  />
+                </th>
+              ) : null}
               <th className="px-2 py-2" title="Opens Shipment 360. Prefers PO when shipment no looks like an ASN ref.">
                 PO / shipment
               </th>
@@ -1602,6 +1696,21 @@ function ControlTowerWorkbenchInner({
                         : ""
                   }`}
                 >
+                  {canUseBulkAlertAck ? (
+                    <td className="px-2 py-2 text-center align-top">
+                      <input
+                        type="checkbox"
+                        aria-label={`Select shipment ${r.orderNumber}`}
+                        checked={selectedShipmentSet.has(r.id)}
+                        onChange={(e) => {
+                          setSelectedShipmentIds((prev) => {
+                            if (e.target.checked) return Array.from(new Set([...prev, r.id]));
+                            return prev.filter((id) => id !== r.id);
+                          });
+                        }}
+                      />
+                    </td>
+                  ) : null}
                   <td className="px-2 py-2 font-medium">
                     <Link href={shipment360Href(r.id, ship360Tab)} className="block text-sky-800 hover:underline">
                       <span className="text-zinc-900">

--- a/src/lib/control-tower/post-actions.test.ts
+++ b/src/lib/control-tower/post-actions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { parseBulkShipmentIds } from "@/lib/control-tower/post-actions";
+
+describe("parseBulkShipmentIds", () => {
+  it("returns unique trimmed IDs", () => {
+    expect(parseBulkShipmentIds([" ship-1 ", "ship-1", "ship-2"])).toEqual(["ship-1", "ship-2"]);
+  });
+
+  it("rejects non-array values", () => {
+    expect(parseBulkShipmentIds("ship-1")).toBe("invalid");
+    expect(parseBulkShipmentIds(null)).toBe("invalid");
+  });
+
+  it("rejects empty lists after trimming", () => {
+    expect(parseBulkShipmentIds(["   ", ""])).toBe("invalid");
+  });
+
+  it("rejects lists over 100 shipment IDs", () => {
+    const overLimit = Array.from({ length: 101 }, (_, i) => `ship-${i + 1}`);
+    expect(parseBulkShipmentIds(overLimit)).toBe("invalid");
+  });
+});

--- a/src/lib/control-tower/post-actions.ts
+++ b/src/lib/control-tower/post-actions.ts
@@ -65,6 +65,19 @@ function parseOptText(v: unknown): string | null | undefined | "invalid" {
   return t;
 }
 
+export function parseBulkShipmentIds(v: unknown): string[] | "invalid" {
+  if (!Array.isArray(v)) return "invalid";
+  const ids = Array.from(
+    new Set(
+      v
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+        .filter((entry) => entry.length > 0),
+    ),
+  );
+  if (ids.length === 0 || ids.length > 100) return "invalid";
+  return ids;
+}
+
 export async function handleControlTowerPost(
   tenantId: string,
   body: Json,
@@ -587,6 +600,66 @@ export async function handleControlTowerPost(
       payload: { fromStatus: alert.status },
     });
     return NextResponse.json({ ok: true });
+  }
+
+  if (action === "bulk_acknowledge_ct_alerts") {
+    const shipmentIds = parseBulkShipmentIds(body.shipmentIds);
+    if (shipmentIds === "invalid") {
+      return bad("shipmentIds must contain 1-100 IDs");
+    }
+    const openAlerts = await prisma.ctAlert.findMany({
+      where: {
+        tenantId,
+        status: "OPEN",
+        shipmentId: { in: shipmentIds },
+      },
+      select: {
+        id: true,
+        shipmentId: true,
+        status: true,
+      },
+    });
+    if (openAlerts.length === 0) {
+      return NextResponse.json({
+        ok: true,
+        acknowledgedAlertCount: 0,
+        selectedShipmentCount: shipmentIds.length,
+        affectedShipmentCount: 0,
+      });
+    }
+    const alertIds = openAlerts.map((alert) => alert.id);
+    const touchedShipmentIds = new Set(openAlerts.map((alert) => alert.shipmentId));
+    const now = new Date();
+    await prisma.ctAlert.updateMany({
+      where: {
+        id: { in: alertIds },
+        status: "OPEN",
+      },
+      data: {
+        status: "ACKNOWLEDGED",
+        acknowledgedAt: now,
+        acknowledgedById: actorId,
+      },
+    });
+    await Promise.all(
+      openAlerts.map((alert) =>
+        writeCtAudit({
+          tenantId,
+          shipmentId: alert.shipmentId,
+          entityType: "CtAlert",
+          entityId: alert.id,
+          action: "acknowledge",
+          actorUserId: actorId,
+          payload: { fromStatus: alert.status, via: "bulk_workbench" },
+        }),
+      ),
+    );
+    return NextResponse.json({
+      ok: true,
+      acknowledgedAlertCount: openAlerts.length,
+      selectedShipmentCount: shipmentIds.length,
+      affectedShipmentCount: touchedShipmentIds.size,
+    });
   }
 
   if (action === "close_ct_alert") {


### PR DESCRIPTION
## Summary
- add a minimal multi-select flow to the Control Tower workbench and a single safe bulk operator action: acknowledge open alerts for selected shipments
- add tenant-scoped backend handling via `bulk_acknowledge_ct_alerts` and per-alert audit writes, reusing existing Control Tower post-action patterns
- update Control Tower gap-map docs and add parser tests for bulk shipment ID validation

## Validation
- Ran `npm run lint && npx tsc --noEmit && npm run test`
- `tsc` is currently blocked by unrelated existing API Hub errors in `src/lib/apihub/connectors-repo.ts` (`apiHubConnectorAuditLog` property missing on Prisma client), so the command chain stops before tests

## Scope Guardrails
- PR includes only:
  - `docs/controltower/GAP_MAP.md`
  - `src/components/control-tower-workbench.tsx`
  - `src/lib/control-tower/post-actions.ts`
  - `src/lib/control-tower/post-actions.test.ts`

Made with [Cursor](https://cursor.com)