### PR TITLE
feat(sales-orders): detail workflow follow-up + PATCH error code contract

### DIFF
--- a/src/app/api/sales-orders/[id]/route.ts
+++ b/src/app/api/sales-orders/[id]/route.ts
@@ -105,7 +105,12 @@ export async function PATCH(
     shipments: row.shipments,
   });
   if (!transition.ok) {
-    const payload: { error: string; activeShipments?: typeof transition.activeShipments } = {
+    const payload: {
+      code: typeof transition.code;
+      error: string;
+      activeShipments?: typeof transition.activeShipments;
+    } = {
+      code: transition.code,
       error: transition.error,
     };
     if (transition.activeShipments) {

--- a/src/app/sales-orders/[id]/page.tsx
+++ b/src/app/sales-orders/[id]/page.tsx
@@ -62,6 +62,9 @@ export default async function SalesOrderDetailPage({
       </div>
     );
   }
+  const activeShipmentCount = row.shipments.filter((s) =>
+    ["SHIPPED", "VALIDATED", "BOOKED", "IN_TRANSIT"].includes(s.status),
+  ).length;
 
   return (
     <main className="mx-auto w-full max-w-5xl px-6 py-8">
@@ -78,6 +81,20 @@ export default async function SalesOrderDetailPage({
           steps={["Step 1: Review customer commitment", "Step 2: Transition SO status", "Step 3: Track linked shipments"]}
         />
       </div>
+      <section className="mt-4 grid gap-3 rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm sm:grid-cols-3">
+        <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">Current status</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900">{row.status}</p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">Linked shipments</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900">{row.shipments.length}</p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">Active shipments</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900">{activeShipmentCount}</p>
+        </div>
+      </section>
       <SalesOrderStatusActions
         salesOrderId={row.id}
         status={row.status}
@@ -107,23 +124,28 @@ export default async function SalesOrderDetailPage({
       </div>
 
       <h2 className="mt-6 text-base font-semibold text-zinc-900">Linked shipments</h2>
-      <p className="mt-1 text-xs text-zinc-500">Shipment links open the Control Tower shipment workspace.</p>
+      <p className="mt-1 text-xs text-zinc-500">Review shipment state and jump into the shipment workspace when needed.</p>
       <ul className="mt-2 space-y-2">
         {row.shipments.length === 0 ? (
           <li className="rounded border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-500">No shipments linked.</li>
         ) : (
           row.shipments.map((s) => (
-            <li key={s.id} className="rounded border border-zinc-200 bg-white px-3 py-2 text-sm">
-              <Link
-                href={`/control-tower/shipments/${s.id}`}
-                className="font-medium text-sky-800 hover:underline"
-                title="Open in Control Tower"
-              >
-                {s.shipmentNo || s.id}
-              </Link>
-              <span className="ml-2 text-zinc-500">
-                {s.status} · {s.transportMode || "—"} · {s.carrier || "—"} · {s.trackingNo || "—"}
-              </span>
+            <li key={s.id} className="rounded-lg border border-zinc-200 bg-white px-3 py-3 text-sm shadow-sm">
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <p className="font-medium text-zinc-900">{s.shipmentNo || s.id}</p>
+                  <p className="text-xs text-zinc-500">
+                    {s.status} · {s.transportMode || "—"} · {s.carrier || "—"} · {s.trackingNo || "—"}
+                  </p>
+                </div>
+                <Link
+                  href={`/control-tower/shipments/${s.id}`}
+                  className="rounded-lg border border-zinc-300 px-2.5 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
+                  title="Open in Control Tower"
+                >
+                  Open shipment
+                </Link>
+              </div>
             </li>
           ))
         )}

--- a/src/components/sales-order-status-actions.tsx
+++ b/src/components/sales-order-status-actions.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { buildSalesOrderPatchStatusErrorMessage } from "@/lib/sales-orders/patch-status-client";
+
 export function SalesOrderStatusActions({
   salesOrderId,
   status,
@@ -14,6 +16,7 @@ export function SalesOrderStatusActions({
 }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   if (!canTransition) return null;
 
@@ -23,40 +26,42 @@ export function SalesOrderStatusActions({
   async function changeStatus(next: "DRAFT" | "OPEN" | "CLOSED") {
     if (busy || next === status) return;
     setBusy(true);
+    setError(null);
     const res = await fetch(`/api/sales-orders/${salesOrderId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status: next }),
     });
-    const payload = (await res.json()) as { error?: string; activeShipments?: Array<{ shipmentNo: string | null; status: string }> };
+    const payload = (await res.json()) as {
+      code?: "INVALID_TRANSITION" | "ACTIVE_SHIPMENTS";
+      error?: string;
+      activeShipments?: Array<{ shipmentNo: string | null; status: string }>;
+    };
     setBusy(false);
     if (!res.ok) {
-      const suffix =
-        payload.activeShipments && payload.activeShipments.length
-          ? ` Active: ${payload.activeShipments
-              .map((s) => `${s.shipmentNo || "shipment"} (${s.status})`)
-              .join(", ")}`
-          : "";
-      window.alert((payload.error || "Could not change status.") + suffix);
+      setError(buildSalesOrderPatchStatusErrorMessage(payload));
       return;
     }
     router.refresh();
   }
 
   return (
-    <div className="mt-3 flex flex-wrap items-center gap-2">
-      <span className="text-xs text-zinc-500">Change status:</span>
-      {options.map((next) => (
-        <button
-          key={next}
-          type="button"
-          disabled={busy}
-          onClick={() => void changeStatus(next)}
-          className="rounded border border-zinc-300 bg-white px-2.5 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50"
-        >
-          {busy ? "Saving..." : next}
-        </button>
-      ))}
-    </div>
+    <section className="mt-3 rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-zinc-500">Transition status</span>
+        {options.map((next) => (
+          <button
+            key={next}
+            type="button"
+            disabled={busy}
+            onClick={() => void changeStatus(next)}
+            className="rounded-xl bg-[var(--arscmp-primary)] px-3 py-1.5 text-xs font-semibold text-white hover:brightness-95 disabled:opacity-50"
+          >
+            {busy ? "Saving..." : `Move to ${next}`}
+          </button>
+        ))}
+      </div>
+      {error ? <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</p> : null}
+    </section>
   );
 }

--- a/src/lib/sales-orders/patch-status-client.test.ts
+++ b/src/lib/sales-orders/patch-status-client.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSalesOrderPatchStatusErrorMessage } from "./patch-status-client";
+
+describe("buildSalesOrderPatchStatusErrorMessage", () => {
+  it("falls back to default message", () => {
+    expect(buildSalesOrderPatchStatusErrorMessage(undefined)).toBe("Could not change status.");
+  });
+
+  it("returns API error for non-active-shipment failures", () => {
+    expect(
+      buildSalesOrderPatchStatusErrorMessage({
+        code: "INVALID_TRANSITION",
+        error: "Cannot change status from DRAFT to DRAFT.",
+      }),
+    ).toBe("Cannot change status from DRAFT to DRAFT.");
+  });
+
+  it("appends active shipment details when payload code matches", () => {
+    expect(
+      buildSalesOrderPatchStatusErrorMessage({
+        code: "ACTIVE_SHIPMENTS",
+        error: "Cannot close sales order while linked shipments are active.",
+        activeShipments: [
+          { shipmentNo: "S-42", status: "IN_TRANSIT" },
+          { shipmentNo: null, status: "BOOKED" },
+        ],
+      }),
+    ).toBe("Cannot close sales order while linked shipments are active. Active: S-42 (IN_TRANSIT), shipment (BOOKED)");
+  });
+});

--- a/src/lib/sales-orders/patch-status-client.ts
+++ b/src/lib/sales-orders/patch-status-client.ts
@@ -1,0 +1,23 @@
+import type { SalesOrderStatusTransitionErrorCode } from "./patch-status";
+
+export type SalesOrderPatchStatusErrorPayload = {
+  code?: SalesOrderStatusTransitionErrorCode;
+  error?: string;
+  activeShipments?: Array<{ shipmentNo: string | null; status: string }>;
+};
+
+export function buildSalesOrderPatchStatusErrorMessage(
+  payload: SalesOrderPatchStatusErrorPayload | null | undefined,
+): string {
+  if (!payload) return "Could not change status.";
+
+  const base = payload.error || "Could not change status.";
+  if (payload.code !== "ACTIVE_SHIPMENTS" || !payload.activeShipments?.length) {
+    return base;
+  }
+
+  const active = payload.activeShipments
+    .map((s) => `${s.shipmentNo || "shipment"} (${s.status})`)
+    .join(", ");
+  return `${base} Active: ${active}`;
+}

--- a/src/lib/sales-orders/patch-status.test.ts
+++ b/src/lib/sales-orders/patch-status.test.ts
@@ -114,6 +114,7 @@ describe("evaluateSalesOrderStatusTransition", () => {
     ).toEqual({
       ok: false,
       status: 409,
+      code: "INVALID_TRANSITION",
       error: "Cannot change status from DRAFT to DRAFT.",
     });
   });
@@ -127,6 +128,7 @@ describe("evaluateSalesOrderStatusTransition", () => {
     expect(r).toEqual({
       ok: false,
       status: 409,
+      code: "ACTIVE_SHIPMENTS",
       error: "Cannot close sales order while linked shipments are active.",
       activeShipments: [{ id: "s1", shipmentNo: "S-1", status: "IN_TRANSIT" }],
     });

--- a/src/lib/sales-orders/patch-status.ts
+++ b/src/lib/sales-orders/patch-status.ts
@@ -1,6 +1,7 @@
 const ACTIVE_SHIPMENT_STATUSES = new Set(["SHIPPED", "VALIDATED", "BOOKED", "IN_TRANSIT"]);
 
 export type SalesOrderHeaderStatus = "DRAFT" | "OPEN" | "CLOSED";
+export type SalesOrderStatusTransitionErrorCode = "INVALID_TRANSITION" | "ACTIVE_SHIPMENTS";
 
 const SALES_ORDER_STATUSES: readonly SalesOrderHeaderStatus[] = ["DRAFT", "OPEN", "CLOSED"];
 
@@ -61,6 +62,7 @@ export type SalesOrderStatusTransitionResult =
   | {
       ok: false;
       status: 409;
+      code: SalesOrderStatusTransitionErrorCode;
       error: string;
       activeShipments?: Array<{ id: string; shipmentNo: string | null; status: string }>;
     };
@@ -76,6 +78,7 @@ export function evaluateSalesOrderStatusTransition(input: {
     return {
       ok: false,
       status: 409,
+      code: "INVALID_TRANSITION",
       error: `Cannot change status from ${current} to ${target}.`,
     };
   }
@@ -86,6 +89,7 @@ export function evaluateSalesOrderStatusTransition(input: {
       return {
         ok: false,
         status: 409,
+        code: "ACTIVE_SHIPMENTS",
         error: "Cannot close sales order while linked shipments are active.",
         activeShipments: active.map((s) => ({
           id: s.id,


### PR DESCRIPTION
## Summary
- improve sales-order detail workflow UX with status transition action styling, inline error presentation, and shipment summary cards
- tighten `PATCH /api/sales-orders/[id]` conflict error contract by returning a stable `code` (`INVALID_TRANSITION` or `ACTIVE_SHIPMENTS`)
- add regression tests for status transition result codes and client-side error message formatting

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`

Made with [Cursor](https://cursor.com)