### PR TITLE
test(tariff): promote import edge cases + API error parity

### DIFF
--- a/src/app/api/tariffs/_lib/tariff-api-error.test.ts
+++ b/src/app/api/tariffs/_lib/tariff-api-error.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { TariffRepoError } from "@/lib/tariff/tariff-repo-error";
 
-import { jsonFromTariffError } from "./tariff-api-error";
+import { jsonFromTariffError, toTariffApiErrorBody } from "./tariff-api-error";
 
 describe("jsonFromTariffError", () => {
+  it("builds stable API error bodies", () => {
+    expect(toTariffApiErrorBody("oops", "BAD_INPUT")).toEqual({ error: "oops", code: "BAD_INPUT" });
+  });
+
   it("returns null for non-TariffRepoError values", () => {
     expect(jsonFromTariffError(new Error("plain"))).toBeNull();
     expect(jsonFromTariffError("string")).toBeNull();
@@ -21,6 +25,6 @@ describe("jsonFromTariffError", () => {
     const res = jsonFromTariffError(new TariffRepoError(code, "msg"));
     expect(res).not.toBeNull();
     expect(res!.status).toBe(expectedStatus);
-    expect(await res!.json()).toEqual({ error: "msg" });
+    expect(await res!.json()).toEqual({ error: "msg", code });
   });
 });

--- a/src/app/api/tariffs/_lib/tariff-api-error.ts
+++ b/src/app/api/tariffs/_lib/tariff-api-error.ts
@@ -2,6 +2,15 @@ import { NextResponse } from "next/server";
 
 import { TariffRepoError } from "@/lib/tariff/tariff-repo-error";
 
+export type TariffApiErrorBody = { error: string; code: TariffRepoError["code"] | "BAD_INPUT" };
+
+export function toTariffApiErrorBody(
+  error: string,
+  code: TariffRepoError["code"] | "BAD_INPUT",
+): TariffApiErrorBody {
+  return { error, code };
+}
+
 export function jsonFromTariffError(e: unknown): NextResponse | null {
   if (!(e instanceof TariffRepoError)) return null;
   const status =
@@ -14,5 +23,5 @@ export function jsonFromTariffError(e: unknown): NextResponse | null {
           : e.code === "BAD_INPUT"
             ? 400
             : 400;
-  return NextResponse.json({ error: e.message }, { status });
+  return NextResponse.json(toTariffApiErrorBody(e.message, e.code), { status });
 }

--- a/src/app/api/tariffs/import-batches/[id]/promote/route.test.ts
+++ b/src/app/api/tariffs/import-batches/[id]/promote/route.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const promoteApprovedStagingRowsToNewVersionMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/tariff/promote-staging-import", () => ({
+  promoteApprovedStagingRowsToNewVersion: promoteApprovedStagingRowsToNewVersionMock,
+}));
+
+describe("POST /api/tariffs/import-batches/[id]/promote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+  });
+
+  it("returns parity error body for invalid JSON payloads", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/tariffs/import-batches/batch-1/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    const response = await POST(request, { params: Promise.resolve({ id: "batch-1" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid JSON.", code: "BAD_INPUT" });
+  });
+
+  it("returns parity error body for malformed promote request shape", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/tariffs/import-batches/batch-1/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const response = await POST(request, { params: Promise.resolve({ id: "batch-1" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "contractHeaderId is required.", code: "BAD_INPUT" });
+    expect(promoteApprovedStagingRowsToNewVersionMock).not.toHaveBeenCalled();
+  });
+
+  it("maps downstream TariffRepoError to status/body parity", async () => {
+    const { POST } = await import("./route");
+    const { TariffRepoError } = await import("@/lib/tariff/tariff-repo-error");
+
+    promoteApprovedStagingRowsToNewVersionMock.mockRejectedValueOnce(
+      new TariffRepoError("CONFLICT", "Import already promoted."),
+    );
+
+    const request = new Request("http://localhost/api/tariffs/import-batches/batch-1/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contractHeaderId: "hdr-1" }),
+    });
+    const response = await POST(request, { params: Promise.resolve({ id: "batch-1" }) });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "Import already promoted.", code: "CONFLICT" });
+  });
+});

--- a/src/app/api/tariffs/import-batches/[id]/promote/route.ts
+++ b/src/app/api/tariffs/import-batches/[id]/promote/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { getActorUserId, requireApiGrant } from "@/lib/authz";
 import { getDemoTenant } from "@/lib/demo-tenant";
 import { parsePromoteImportRequestBody } from "@/app/api/tariffs/import-batches/_lib/promote-import-body";
-import { jsonFromTariffError } from "@/app/api/tariffs/_lib/tariff-api-error";
+import { jsonFromTariffError, toTariffApiErrorBody } from "@/app/api/tariffs/_lib/tariff-api-error";
 import { promoteApprovedStagingRowsToNewVersion } from "@/lib/tariff/promote-staging-import";
 
 export const dynamic = "force-dynamic";
@@ -24,11 +24,11 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+    return NextResponse.json(toTariffApiErrorBody("Invalid JSON.", "BAD_INPUT"), { status: 400 });
   }
   const parsed = parsePromoteImportRequestBody(body);
   if (!parsed.ok) {
-    return NextResponse.json({ error: parsed.error }, { status: 400 });
+    return NextResponse.json(toTariffApiErrorBody(parsed.error, "BAD_INPUT"), { status: 400 });
   }
   const { contractHeaderId } = parsed;
 

--- a/src/app/api/tariffs/import-batches/_lib/promote-import-body.test.ts
+++ b/src/app/api/tariffs/import-batches/_lib/promote-import-body.test.ts
@@ -42,4 +42,15 @@ describe("parsePromoteImportRequestBody", () => {
       error: "Expected object body.",
     });
   });
+
+  it("rejects primitive payload shapes", () => {
+    expect(parsePromoteImportRequestBody("abc")).toEqual({
+      ok: false,
+      error: "Expected object body.",
+    });
+    expect(parsePromoteImportRequestBody(42)).toEqual({
+      ok: false,
+      error: "Expected object body.",
+    });
+  });
 });

--- a/src/lib/tariff/promote-staging-import.test.ts
+++ b/src/lib/tariff/promote-staging-import.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { promoteStagingImportAmountPresent } from "@/lib/tariff/promote-staging-import";
+import {
+  findDuplicatePromotableRows,
+  isSupportedPromoteRateType,
+  promoteStagingImportAmountPresent,
+} from "@/lib/tariff/promote-staging-import";
 
 describe("promoteStagingImportAmountPresent", () => {
   it("treats numeric zero and string zero as present", () => {
@@ -27,5 +31,68 @@ describe("promoteStagingImportAmountPresent", () => {
     expect(promoteStagingImportAmountPresent(null)).toBe(false);
     expect(promoteStagingImportAmountPresent(undefined)).toBe(false);
     expect(promoteStagingImportAmountPresent({})).toBe(false);
+  });
+});
+
+describe("findDuplicatePromotableRows", () => {
+  it("flags duplicate normalized payloads for equivalent approved rows", () => {
+    const duplicate = findDuplicatePromotableRows([
+      {
+        id: "row-1",
+        rowType: "RATE_LINE_CANDIDATE",
+        normalizedPayload: { rateType: "BASE_RATE", currency: "USD", unitBasis: "CONTAINER", amount: "100" },
+      },
+      {
+        id: "row-2",
+        rowType: "RATE_LINE_CANDIDATE",
+        normalizedPayload: { unitBasis: "CONTAINER", amount: "100", currency: "USD", rateType: "BASE_RATE" },
+      },
+    ]);
+    expect(duplicate).toEqual({ firstRowId: "row-1", duplicateRowId: "row-2" });
+  });
+
+  it("treats different row types or payload values as non-duplicates", () => {
+    expect(
+      findDuplicatePromotableRows([
+        {
+          id: "row-1",
+          rowType: "RATE_LINE_CANDIDATE",
+          normalizedPayload: { rateType: "BASE_RATE", currency: "USD", unitBasis: "CONTAINER", amount: "100" },
+        },
+        {
+          id: "row-2",
+          rowType: "CHARGE_LINE_CANDIDATE",
+          normalizedPayload: { rawChargeName: "BAF", currency: "USD", unitBasis: "CONTAINER", amount: "100" },
+        },
+        {
+          id: "row-3",
+          rowType: "RATE_LINE_CANDIDATE",
+          normalizedPayload: { rateType: "BASE_RATE", currency: "USD", unitBasis: "CONTAINER", amount: "101" },
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it("ignores malformed normalized payload objects", () => {
+    expect(
+      findDuplicatePromotableRows([
+        { id: "row-1", rowType: "RATE_LINE_CANDIDATE", normalizedPayload: null },
+        { id: "row-2", rowType: "RATE_LINE_CANDIDATE", normalizedPayload: [] },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("isSupportedPromoteRateType", () => {
+  it("accepts known tariff line rate type enums", () => {
+    expect(isSupportedPromoteRateType("BASE_RATE")).toBe(true);
+    expect(isSupportedPromoteRateType("ALL_IN")).toBe(true);
+  });
+
+  it("rejects unsupported or malformed values", () => {
+    expect(isSupportedPromoteRateType("NOT_A_REAL_RATE_TYPE")).toBe(false);
+    expect(isSupportedPromoteRateType("base_rate")).toBe(false);
+    expect(isSupportedPromoteRateType(123)).toBe(false);
+    expect(isSupportedPromoteRateType(null)).toBe(false);
   });
 });

--- a/src/lib/tariff/promote-staging-import.ts
+++ b/src/lib/tariff/promote-staging-import.ts
@@ -1,4 +1,4 @@
-import type { TariffLineRateType } from "@prisma/client";
+import { TariffLineRateType } from "@prisma/client";
 
 import { recordTariffAuditLog } from "@/lib/tariff/audit-log";
 import { createTariffChargeLine } from "@/lib/tariff/charge-lines";
@@ -11,6 +11,7 @@ import { prisma } from "@/lib/prisma";
 
 const RATE_ROW = "RATE_LINE_CANDIDATE";
 const CHARGE_ROW = "CHARGE_LINE_CANDIDATE";
+const TARIFF_LINE_RATE_TYPE_SET = new Set<string>(Object.values(TariffLineRateType));
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return v != null && typeof v === "object" && !Array.isArray(v);
@@ -30,6 +31,32 @@ function pickOptionalString(o: Record<string, unknown>, key: string): string | n
   if (typeof v !== "string") return undefined;
   const t = v.trim();
   return t ? t : null;
+}
+
+function buildNormalizedPromoteRowKey(rowType: string, payload: Record<string, unknown>): string {
+  const keys = Object.keys(payload).sort();
+  const normalizedPayload = keys
+    .map((key) => [key, payload[key]] as const)
+    .filter(([, value]) => value !== undefined);
+  return JSON.stringify([rowType, normalizedPayload]);
+}
+
+export function findDuplicatePromotableRows(
+  rows: Array<{ id: string; rowType: string; normalizedPayload: unknown }>,
+): { duplicateRowId: string; firstRowId: string } | null {
+  const seen = new Map<string, string>();
+  for (const row of rows) {
+    if (!isRecord(row.normalizedPayload)) continue;
+    const key = buildNormalizedPromoteRowKey(row.rowType, row.normalizedPayload);
+    const first = seen.get(key);
+    if (first) return { duplicateRowId: row.id, firstRowId: first };
+    seen.set(key, row.id);
+  }
+  return null;
+}
+
+export function isSupportedPromoteRateType(rateType: unknown): rateType is TariffLineRateType {
+  return typeof rateType === "string" && TARIFF_LINE_RATE_TYPE_SET.has(rateType);
 }
 
 /** Whether a staging row `normalizedPayload.amount` is acceptable for Excel promote (exported for tests). */
@@ -59,6 +86,10 @@ export async function promoteApprovedStagingRowsToNewVersion(params: {
     batchId: params.importBatchId,
   });
 
+  if (batch.reviewStatus === "APPLIED") {
+    throw new TariffRepoError("CONFLICT", "Batch is already promoted.");
+  }
+
   if (batch.reviewStatus !== "READY_TO_APPLY") {
     throw new TariffRepoError(
       "BAD_INPUT",
@@ -78,6 +109,14 @@ export async function promoteApprovedStagingRowsToNewVersion(params: {
       (r.rowType === RATE_ROW || r.rowType === CHARGE_ROW) &&
       TARIFF_IMPORT_STAGING_ROW_TYPE_SET.has(r.rowType),
   );
+
+  const duplicateRows = findDuplicatePromotableRows(rows);
+  if (duplicateRows) {
+    throw new TariffRepoError(
+      "BAD_INPUT",
+      `Duplicate approved staging row payloads detected (${duplicateRows.firstRowId} and ${duplicateRows.duplicateRowId}).`,
+    );
+  }
 
   if (rows.length === 0) {
     throw new TariffRepoError(
@@ -111,6 +150,9 @@ export async function promoteApprovedStagingRowsToNewVersion(params: {
         const unitBasis = pickString(norm, "unitBasis");
         const currency = pickString(norm, "currency");
         const amount = norm.amount;
+        if (rateType && !isSupportedPromoteRateType(rateType)) {
+          throw new TariffRepoError("BAD_INPUT", `Rate staging row ${row.id} has unsupported rateType '${rateType}'.`);
+        }
         if (!rateType || !unitBasis || !currency || !promoteStagingImportAmountPresent(amount)) {
           throw new TariffRepoError(
             "BAD_INPUT",


### PR DESCRIPTION
## What changed
- Added focused promote API route tests covering malformed JSON, malformed payload shape, and TariffRepoError parity mapping.
- Expanded import-promote library tests for duplicate/ambiguous row detection, unsupported `rateType` enums, and existing amount validation edge-cases.
- Hardened promote behavior with targeted guards for idempotent repeat promote attempts (`APPLIED` -> `CONFLICT`) and duplicate approved payload detection.
- Aligned promote API error bodies to a stable structure (`{ error, code }`) while preserving UI-compatible `error` strings.

## Why this reduces regression risk
- Locks the failure contract for equivalent import-promote failures so client behavior remains predictable across validation and repository-level errors.
- Adds explicit tests for high-risk edge cases (malformed payloads, unsupported enums, duplicate rows, repeated promotes) that previously could regress silently.

## Test commands run + result
- `npm run lint` -> pass (warnings only, pre-existing and unrelated outside tariff scope).
- `npx tsc --noEmit` -> pass.
- `npx vitest run src/lib/tariff/promote-staging-import.test.ts src/app/api/tariffs/_lib/tariff-api-error.test.ts src/app/api/tariffs/import-batches/_lib/promote-import-body.test.ts "src/app/api/tariffs/import-batches/[id]/promote/route.test.ts"` -> pass (4 files, 23 tests).

## Known follow-ups
- If broader tariff APIs should adopt `{ error, code }` parity uniformly, mirror this pattern in other tariff route handlers in a separate pass.

Made with [Cursor](https://cursor.com)