### PR TITLE
chore(api): freeze shared error/guard response contract baseline

### DIFF
--- a/docs/engineering/api-error-guard-contract-baseline.md
+++ b/docs/engineering/api-error-guard-contract-baseline.md
@@ -1,0 +1,53 @@
+# API Error/Guard Contract Baseline
+
+## Scope
+
+This baseline freezes one shared response contract for API domain errors and permission/guard failures.
+
+- **Body shape:** `{ error: string; code: string; ...optionalMetadata }`
+- **Status:** explicit HTTP status selected by code mapping (`statusFromErrorCode`) or direct guard status.
+- **Response helper:** `toApiErrorResponse(...)` from `src/app/api/_lib/api-error-contract.ts`.
+
+## Contract Rules
+
+1. Every non-2xx API error response should include both `error` and `code`.
+2. Keep `error` human-readable and suitable for logs and troubleshooting.
+3. Keep `code` machine-stable (UPPER_SNAKE_CASE) for client branching and tests.
+4. Use optional metadata only for actionable remediation context (for example `migrationsHint`).
+5. Map status from code with `statusFromErrorCode` for repo/domain errors; set status directly for pure guard checks.
+
+## Helper Location Policy
+
+- **Shared contract helpers live in:** `src/app/api/_lib/`.
+- **Slice adapters stay local** (for example `src/app/api/rfq/_lib/rfq-api-error.ts`) and should only:
+  - narrow unknown errors to the slice error class;
+  - map slice-specific codes to status;
+  - delegate final body/response shaping to shared contract helpers.
+- **Permission/guard checks** that return `NextResponse` should also delegate to the shared contract helper to keep shape parity.
+
+## Examples
+
+```ts
+import { statusFromErrorCode, toApiErrorResponse } from "@/app/api/_lib/api-error-contract";
+
+const status = statusFromErrorCode(e.code, { NOT_FOUND: 404, CONFLICT: 409 }, 400);
+return toApiErrorResponse({ error: e.message, code: e.code, status });
+```
+
+```ts
+return toApiErrorResponse({
+  error: "Forbidden: requires org.tariffs -> edit.",
+  code: "FORBIDDEN",
+  status: 403,
+});
+```
+
+## Backward Compatibility Note
+
+This baseline introduces `code` in two representative slices that previously returned `{ error }` only:
+
+- RFQ API error adapter (`jsonFromRfqError`)
+- Booking pricing snapshot API error adapter (`jsonFromSnapshotError`)
+- Pricing snapshot guard helper responses in `require-pricing-snapshot-access`
+
+Clients that parsed only `error` remain compatible; clients that validated exact key sets should accept the additional `code` field.

--- a/src/app/api/_lib/api-error-contract.test.ts
+++ b/src/app/api/_lib/api-error-contract.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { statusFromErrorCode, toApiErrorBody, toApiErrorResponse } from "./api-error-contract";
+
+describe("api-error-contract", () => {
+  it("builds a stable error body shape", () => {
+    expect(toApiErrorBody("Forbidden", "FORBIDDEN")).toEqual({
+      error: "Forbidden",
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("supports additional metadata", () => {
+    expect(toApiErrorBody("Schema not ready", "SCHEMA_NOT_READY", { migrationsHint: "run db:migrate" })).toEqual({
+      error: "Schema not ready",
+      code: "SCHEMA_NOT_READY",
+      migrationsHint: "run db:migrate",
+    });
+  });
+
+  it("returns NextResponse with requested status", async () => {
+    const res = toApiErrorResponse({ error: "Missing", code: "NOT_FOUND", status: 404 });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Missing", code: "NOT_FOUND" });
+  });
+
+  it("maps known codes and falls back to default status", () => {
+    expect(statusFromErrorCode("NOT_FOUND", { NOT_FOUND: 404 }, 400)).toBe(404);
+    expect(statusFromErrorCode("UNKNOWN", { UNKNOWN: 422 }, 400)).toBe(422);
+    expect(statusFromErrorCode("UNKNOWN", {}, 400)).toBe(400);
+  });
+});

--- a/src/app/api/_lib/api-error-contract.ts
+++ b/src/app/api/_lib/api-error-contract.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+export type ApiErrorBody<
+  TCode extends string = string,
+  TExtra extends Record<string, unknown> = Record<never, never>,
+> = { error: string; code: TCode } & TExtra;
+
+type ApiErrorResponseParams<TCode extends string, TExtra extends Record<string, unknown>> = {
+  error: string;
+  code: TCode;
+  status: number;
+  extra?: TExtra;
+};
+
+export function toApiErrorBody<
+  TCode extends string,
+  TExtra extends Record<string, unknown> = Record<never, never>,
+>(error: string, code: TCode, extra?: TExtra): ApiErrorBody<TCode, TExtra> {
+  return {
+    error,
+    code,
+    ...(extra ?? ({} as TExtra)),
+  };
+}
+
+export function toApiErrorResponse<
+  TCode extends string,
+  TExtra extends Record<string, unknown> = Record<never, never>,
+>(params: ApiErrorResponseParams<TCode, TExtra>): NextResponse {
+  return NextResponse.json(toApiErrorBody(params.error, params.code, params.extra), {
+    status: params.status,
+  });
+}
+
+export function statusFromErrorCode<TCode extends string>(
+  code: TCode,
+  statusByCode: Partial<Record<TCode, number>>,
+  fallbackStatus = 400,
+): number {
+  return statusByCode[code] ?? fallbackStatus;
+}

--- a/src/app/api/booking-pricing-snapshots/_lib/require-pricing-snapshot-access.ts
+++ b/src/app/api/booking-pricing-snapshots/_lib/require-pricing-snapshot-access.ts
@@ -1,25 +1,26 @@
 import { NextResponse } from "next/server";
 
+import { toApiErrorResponse } from "@/app/api/_lib/api-error-contract";
 import { getDemoTenant } from "@/lib/demo-tenant";
 import { getViewerGrantSet, viewerHas } from "@/lib/authz";
 
 export async function requirePricingSnapshotRead(): Promise<NextResponse | null> {
   const tenant = await getDemoTenant();
   if (!tenant) {
-    return NextResponse.json(
-      { error: "Demo tenant not found. Run `npm run db:seed` to create starter data." },
-      { status: 404 },
-    );
+    return toApiErrorResponse({
+      error: "Demo tenant not found. Run `npm run db:seed` to create starter data.",
+      code: "TENANT_NOT_FOUND",
+      status: 404,
+    });
   }
   const access = await getViewerGrantSet();
   if (!access?.user) {
-    return NextResponse.json(
-      {
-        error:
-          "No active demo user for this session. Open Settings → Demo session (/settings/demo) to choose who you are acting as.",
-      },
-      { status: 403 },
-    );
+    return toApiErrorResponse({
+      error:
+        "No active demo user for this session. Open Settings → Demo session (/settings/demo) to choose who you are acting as.",
+      code: "NO_ACTIVE_USER",
+      status: 403,
+    });
   }
   const g = access.grantSet;
   if (
@@ -27,13 +28,11 @@ export async function requirePricingSnapshotRead(): Promise<NextResponse | null>
     !viewerHas(g, "org.rfq", "view") &&
     !viewerHas(g, "org.invoice_audit", "view")
   ) {
-    return NextResponse.json(
-      {
-        error:
-          "Forbidden: requires org.tariffs → view, org.rfq → view, or org.invoice_audit → view.",
-      },
-      { status: 403 },
-    );
+    return toApiErrorResponse({
+      error: "Forbidden: requires org.tariffs → view, org.rfq → view, or org.invoice_audit → view.",
+      code: "FORBIDDEN",
+      status: 403,
+    });
   }
   return null;
 }
@@ -46,16 +45,24 @@ export async function requirePricingSnapshotWriteForSource(params: {
 
   const access = await getViewerGrantSet();
   if (!access?.user) {
-    return NextResponse.json({ error: "No active user." }, { status: 403 });
+    return toApiErrorResponse({ error: "No active user.", code: "NO_ACTIVE_USER", status: 403 });
   }
   const g = access.grantSet;
   if (params.sourceType === "TARIFF_CONTRACT_VERSION" || params.sourceType === "COMPOSITE_CONTRACT_VERSION") {
     if (!viewerHas(g, "org.tariffs", "edit")) {
-      return NextResponse.json({ error: "Forbidden: requires org.tariffs → edit." }, { status: 403 });
+      return toApiErrorResponse({
+        error: "Forbidden: requires org.tariffs → edit.",
+        code: "FORBIDDEN",
+        status: 403,
+      });
     }
   } else {
     if (!viewerHas(g, "org.rfq", "edit")) {
-      return NextResponse.json({ error: "Forbidden: requires org.rfq → edit." }, { status: 403 });
+      return toApiErrorResponse({
+        error: "Forbidden: requires org.rfq → edit.",
+        code: "FORBIDDEN",
+        status: 403,
+      });
     }
   }
   return null;

--- a/src/app/api/booking-pricing-snapshots/_lib/snapshot-api-error.test.ts
+++ b/src/app/api/booking-pricing-snapshots/_lib/snapshot-api-error.test.ts
@@ -18,6 +18,6 @@ describe("jsonFromSnapshotError", () => {
     const res = jsonFromSnapshotError(new SnapshotRepoError(code, "msg"));
     expect(res).not.toBeNull();
     expect(res!.status).toBe(expectedStatus);
-    expect(await res!.json()).toEqual({ error: "msg" });
+    expect(await res!.json()).toEqual({ error: "msg", code });
   });
 });

--- a/src/app/api/booking-pricing-snapshots/_lib/snapshot-api-error.ts
+++ b/src/app/api/booking-pricing-snapshots/_lib/snapshot-api-error.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from "next/server";
 
+import { statusFromErrorCode, toApiErrorResponse } from "@/app/api/_lib/api-error-contract";
 import { SnapshotRepoError } from "@/lib/booking-pricing-snapshot/snapshot-repo-error";
 
 export function jsonFromSnapshotError(e: unknown): NextResponse | null {
   if (!(e instanceof SnapshotRepoError)) return null;
-  const status = e.code === "NOT_FOUND" ? 404 : e.code === "FORBIDDEN" ? 403 : 400;
-  return NextResponse.json({ error: e.message }, { status });
+  const status = statusFromErrorCode(
+    e.code,
+    {
+      NOT_FOUND: 404,
+      FORBIDDEN: 403,
+      BAD_INPUT: 400,
+    },
+    400,
+  );
+  return toApiErrorResponse({ error: e.message, code: e.code, status });
 }

--- a/src/app/api/rfq/_lib/rfq-api-error.test.ts
+++ b/src/app/api/rfq/_lib/rfq-api-error.test.ts
@@ -18,6 +18,6 @@ describe("jsonFromRfqError", () => {
     const res = jsonFromRfqError(new RfqRepoError(code, "msg"));
     expect(res).not.toBeNull();
     expect(res!.status).toBe(expectedStatus);
-    expect(await res!.json()).toEqual({ error: "msg" });
+    expect(await res!.json()).toEqual({ error: "msg", code });
   });
 });

--- a/src/app/api/rfq/_lib/rfq-api-error.ts
+++ b/src/app/api/rfq/_lib/rfq-api-error.ts
@@ -1,10 +1,18 @@
 import { NextResponse } from "next/server";
 
+import { statusFromErrorCode, toApiErrorResponse } from "@/app/api/_lib/api-error-contract";
 import { RfqRepoError } from "@/lib/rfq/rfq-repo-error";
 
 export function jsonFromRfqError(e: unknown): NextResponse | null {
   if (!(e instanceof RfqRepoError)) return null;
-  const status =
-    e.code === "NOT_FOUND" ? 404 : e.code === "CONFLICT" ? 409 : 400;
-  return NextResponse.json({ error: e.message }, { status });
+  const status = statusFromErrorCode(
+    e.code,
+    {
+      NOT_FOUND: 404,
+      CONFLICT: 409,
+      BAD_INPUT: 400,
+    },
+    400,
+  );
+  return toApiErrorResponse({ error: e.message, code: e.code, status });
 }

--- a/src/app/api/tariffs/_lib/tariff-api-error.ts
+++ b/src/app/api/tariffs/_lib/tariff-api-error.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { statusFromErrorCode, toApiErrorBody, toApiErrorResponse } from "@/app/api/_lib/api-error-contract";
 import { TariffRepoError } from "@/lib/tariff/tariff-repo-error";
 
 export type TariffApiErrorBody = { error: string; code: TariffRepoError["code"] | "BAD_INPUT" };
@@ -8,20 +9,21 @@ export function toTariffApiErrorBody(
   error: string,
   code: TariffRepoError["code"] | "BAD_INPUT",
 ): TariffApiErrorBody {
-  return { error, code };
+  return toApiErrorBody(error, code);
 }
 
 export function jsonFromTariffError(e: unknown): NextResponse | null {
   if (!(e instanceof TariffRepoError)) return null;
-  const status =
-    e.code === "NOT_FOUND"
-      ? 404
-      : e.code === "TENANT_MISMATCH"
-        ? 403
-        : e.code === "VERSION_FROZEN" || e.code === "CONFLICT"
-          ? 409
-          : e.code === "BAD_INPUT"
-            ? 400
-            : 400;
-  return NextResponse.json(toTariffApiErrorBody(e.message, e.code), { status });
+  const status = statusFromErrorCode(
+    e.code,
+    {
+      NOT_FOUND: 404,
+      TENANT_MISMATCH: 403,
+      VERSION_FROZEN: 409,
+      CONFLICT: 409,
+      BAD_INPUT: 400,
+    },
+    400,
+  );
+  return toApiErrorResponse({ error: e.message, code: e.code, status });
 }


### PR DESCRIPTION
## Summary
- add shared API error/guard contract helpers under `src/app/api/_lib` with stable `{ error, code }` response shape and status mapping helper
- migrate representative tariff, RFQ, and booking pricing snapshot adapters plus one guard helper to the shared contract
- document contract rules, helper placement policy, examples, and backward-compat notes in `docs/engineering/api-error-guard-contract-baseline.md`

## Validation
- [x] `npm run lint` (warnings only in existing out-of-scope files)
- [x] `npx tsc --noEmit`
- [x] `npm test`

Made with [Cursor](https://cursor.com)