### PR TITLE
test(control-tower): add API route contract coverage and error parity

### DIFF
--- a/src/app/api/control-tower/ops/run-escalation/route.test.ts
+++ b/src/app/api/control-tower/ops/run-escalation/route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const runSlaEscalationsForTenantMock = vi.fn();
+const writeCtAuditMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/control-tower/sla-escalation", () => ({
+  runSlaEscalationsForTenant: runSlaEscalationsForTenantMock,
+}));
+
+vi.mock("@/lib/control-tower/audit", () => ({
+  writeCtAudit: writeCtAuditMock,
+}));
+
+describe("POST /api/control-tower/ops/run-escalation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    runSlaEscalationsForTenantMock.mockResolvedValue({ escalatedCount: 3, dryRun: false });
+    writeCtAuditMock.mockResolvedValue(undefined);
+  });
+
+  it("returns gate response parity when grant check denies", async () => {
+    const gate = new Response(JSON.stringify({ error: "Forbidden." }), { status: 403 });
+    requireApiGrantMock.mockResolvedValueOnce(gate);
+
+    const { POST } = await import("./route");
+    const response = await POST(new Request("http://localhost/api/control-tower/ops/run-escalation", { method: "POST" }));
+
+    expect(response).toBe(gate);
+  });
+
+  it("returns stable tenant-missing error payload", async () => {
+    getDemoTenantMock.mockResolvedValueOnce(null);
+
+    const { POST } = await import("./route");
+    const response = await POST(new Request("http://localhost/api/control-tower/ops/run-escalation", { method: "POST" }));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Tenant not found." });
+  });
+
+  it("returns stable actor-missing error payload", async () => {
+    getActorUserIdMock.mockResolvedValueOnce(null);
+
+    const { POST } = await import("./route");
+    const response = await POST(new Request("http://localhost/api/control-tower/ops/run-escalation", { method: "POST" }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "No active user." });
+  });
+
+  it("treats invalid JSON as empty body and still returns success shape", async () => {
+    const request = new Request("http://localhost/api/control-tower/ops/run-escalation", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, escalatedCount: 3, dryRun: false });
+    expect(runSlaEscalationsForTenantMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      actorUserId: "user-1",
+      dryRun: false,
+    });
+  });
+
+  it("passes dryRun=true through and writes audit payload", async () => {
+    runSlaEscalationsForTenantMock.mockResolvedValueOnce({ escalatedCount: 0, dryRun: true });
+
+    const request = new Request("http://localhost/api/control-tower/ops/run-escalation", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ dryRun: true }),
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, escalatedCount: 0, dryRun: true });
+    expect(runSlaEscalationsForTenantMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      actorUserId: "user-1",
+      dryRun: true,
+    });
+    expect(writeCtAuditMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      shipmentId: null,
+      entityType: "ControlTowerOps",
+      entityId: "sla_escalation",
+      action: "ops_run_sla_escalation",
+      actorUserId: "user-1",
+      payload: { escalatedCount: 0, dryRun: true },
+    });
+  });
+});

--- a/src/app/api/control-tower/ops/summary/route.test.ts
+++ b/src/app/api/control-tower/ops/summary/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const getControlTowerPortalContextMock = vi.fn();
+const getControlTowerOpsSummaryMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/control-tower/viewer", () => ({
+  getControlTowerPortalContext: getControlTowerPortalContextMock,
+}));
+
+vi.mock("@/lib/control-tower/ops-summary", () => ({
+  getControlTowerOpsSummary: getControlTowerOpsSummaryMock,
+}));
+
+describe("GET /api/control-tower/ops/summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    getControlTowerPortalContextMock.mockResolvedValue({ timezone: "UTC" });
+    getControlTowerOpsSummaryMock.mockResolvedValue({ overdueShipmentCount: 4 });
+  });
+
+  it("returns gate response parity when grant check denies", async () => {
+    const gate = new Response(JSON.stringify({ error: "Forbidden." }), { status: 403 });
+    requireApiGrantMock.mockResolvedValueOnce(gate);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response).toBe(gate);
+  });
+
+  it("returns stable tenant-missing error payload", async () => {
+    getDemoTenantMock.mockResolvedValueOnce(null);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Tenant not found." });
+  });
+
+  it("returns stable actor-missing error payload", async () => {
+    getActorUserIdMock.mockResolvedValueOnce(null);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "No active user." });
+  });
+
+  it("returns ops summary payload on happy path", async () => {
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ overdueShipmentCount: 4 });
+    expect(getControlTowerPortalContextMock).toHaveBeenCalledWith("user-1");
+    expect(getControlTowerOpsSummaryMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      ctx: { timezone: "UTC" },
+    });
+  });
+});

--- a/src/app/api/control-tower/route.test.ts
+++ b/src/app/api/control-tower/route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const handleControlTowerPostMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/control-tower/post-actions", () => ({
+  handleControlTowerPost: handleControlTowerPostMock,
+}));
+
+describe("POST /api/control-tower", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    handleControlTowerPostMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+
+  it("returns gate response parity when grant check denies", async () => {
+    const gate = new Response(JSON.stringify({ error: "Forbidden." }), { status: 403 });
+    requireApiGrantMock.mockResolvedValueOnce(gate);
+
+    const { POST } = await import("./route");
+    const response = await POST(new Request("http://localhost/api/control-tower", { method: "POST" }));
+
+    expect(response).toBe(gate);
+  });
+
+  it("returns stable tenant-missing error payload", async () => {
+    getDemoTenantMock.mockResolvedValueOnce(null);
+
+    const { POST } = await import("./route");
+    const response = await POST(new Request("http://localhost/api/control-tower", { method: "POST" }));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Tenant not found." });
+  });
+
+  it("passes object body through on happy path", async () => {
+    const requestBody = { action: "mark_seen", shipmentId: "ship-1" };
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/control-tower", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(requestBody),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(handleControlTowerPostMock).toHaveBeenCalledWith("tenant-1", requestBody);
+  });
+
+  it("uses empty object body when JSON is invalid", async () => {
+    const { POST } = await import("./route");
+    await POST(
+      new Request("http://localhost/api/control-tower", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      }),
+    );
+
+    expect(handleControlTowerPostMock).toHaveBeenCalledWith("tenant-1", {});
+  });
+});


### PR DESCRIPTION
## Summary
- Add contract tests for `POST /api/control-tower`, `GET /api/control-tower/ops/summary`, and `POST /api/control-tower/ops/run-escalation`.
- Cover happy paths plus key failure paths for tenant/user guards and gate pass-through parity behavior.
- Assert stable error response shapes and status-code parity for route-level contracts.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/app/api/control-tower/route.test.ts src/app/api/control-tower/ops/summary/route.test.ts src/app/api/control-tower/ops/run-escalation/route.test.ts`

Made with [Cursor](https://cursor.com)