### PR TITLE
test(crm): add API route contract coverage and error parity

### DIFF
--- a/src/app/api/crm/accounts/route.test.ts
+++ b/src/app/api/crm/accounts/route.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const crmTenantFilterMock = vi.fn();
+
+const crmAccountFindManyMock = vi.fn();
+const crmAccountCreateMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/crm-scope", () => ({
+  crmTenantFilter: crmTenantFilterMock,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    crmAccount: {
+      findMany: crmAccountFindManyMock,
+      create: crmAccountCreateMock,
+    },
+  },
+}));
+
+describe("CRM accounts route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    crmTenantFilterMock.mockResolvedValue({ tenantId: "tenant-1" });
+  });
+
+  it("GET returns 403 auth shape when actor is missing", async () => {
+    getActorUserIdMock.mockResolvedValueOnce(null);
+    const { GET } = await import("./route");
+
+    const response = await GET(new Request("http://localhost/api/crm/accounts"));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "No active user." });
+    expect(crmAccountFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("GET returns accounts array contract", async () => {
+    const accountRow = {
+      id: "acc-1",
+      name: "Acme Co",
+      legalName: "Acme Company",
+      accountType: "CUSTOMER",
+      lifecycle: "ACTIVE",
+      industry: "Logistics",
+      strategicFlag: false,
+      ownerUserId: "user-1",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      owner: { id: "user-1", name: "Alex", email: "alex@example.com" },
+      _count: { contacts: 3, opportunities: 2 },
+    };
+    crmAccountFindManyMock.mockResolvedValueOnce([accountRow]);
+    const { GET } = await import("./route");
+
+    const response = await GET(new Request("http://localhost/api/crm/accounts?q=acme"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      accounts: [
+        expect.objectContaining({
+          id: "acc-1",
+          name: "Acme Co",
+          ownerUserId: "user-1",
+        }),
+      ],
+    });
+    expect(crmAccountFindManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST returns 400 with stable validation error shape", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "name is required." });
+    expect(crmAccountCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("POST returns 201 with created account contract", async () => {
+    crmAccountCreateMock.mockResolvedValueOnce({
+      id: "acc-2",
+      name: "Beta LLC",
+      accountType: "PROSPECT",
+      lifecycle: "ACTIVE",
+      ownerUserId: "user-1",
+    });
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: " Beta LLC " }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({
+      account: expect.objectContaining({
+        id: "acc-2",
+        name: "Beta LLC",
+        ownerUserId: "user-1",
+      }),
+    });
+  });
+});

--- a/src/app/api/crm/leads/[id]/convert/route.test.ts
+++ b/src/app/api/crm/leads/[id]/convert/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const userHasGlobalGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+
+const crmLeadFindFirstMock = vi.fn();
+const crmAccountFindFirstMock = vi.fn();
+const transactionMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+  userHasGlobalGrant: userHasGlobalGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    crmLead: {
+      findFirst: crmLeadFindFirstMock,
+    },
+    crmAccount: {
+      findFirst: crmAccountFindFirstMock,
+    },
+    $transaction: transactionMock,
+  },
+}));
+
+describe("CRM lead conversion route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    userHasGlobalGrantMock.mockResolvedValue(false);
+  });
+
+  it("returns 400 parity error for invalid JSON payload", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/leads/lead-1/convert", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: "lead-1" }) });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid JSON body." });
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 contract when lead is missing", async () => {
+    crmLeadFindFirstMock.mockResolvedValueOnce(null);
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/leads/lead-404/convert", {
+      method: "POST",
+      body: "",
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: "lead-404" }) });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Lead not found." });
+  });
+
+  it("returns 403 contract when actor does not own lead", async () => {
+    crmLeadFindFirstMock.mockResolvedValueOnce({
+      id: "lead-1",
+      tenantId: "tenant-1",
+      ownerUserId: "other-user",
+      status: "QUALIFIED",
+    });
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/leads/lead-1/convert", {
+      method: "POST",
+      body: "",
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: "lead-1" }) });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "You can only convert leads you own.",
+    });
+  });
+
+  it("returns 201 with conversion payload contract", async () => {
+    crmLeadFindFirstMock.mockResolvedValueOnce({
+      id: "lead-1",
+      tenantId: "tenant-1",
+      ownerUserId: "user-1",
+      status: "QUALIFIED",
+      companyName: "Acme",
+      contactFirstName: "A",
+      contactLastName: "B",
+      contactEmail: "ab@example.com",
+      contactPhone: null,
+      qualificationNotes: "ready",
+    });
+    transactionMock.mockResolvedValueOnce({
+      account: { id: "acc-1", name: "Acme" },
+      contact: { id: "con-1", firstName: "A", lastName: "B" },
+      opportunity: { id: "opp-1", name: "Acme — New opportunity" },
+      linkedExistingAccount: false,
+    });
+
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/leads/lead-1/convert", {
+      method: "POST",
+      body: "",
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: "lead-1" }) });
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({
+      account: expect.objectContaining({ id: "acc-1", name: "Acme" }),
+      contact: expect.objectContaining({ id: "con-1" }),
+      opportunity: expect.objectContaining({ id: "opp-1" }),
+      linkedExistingAccount: false,
+    });
+  });
+});

--- a/src/app/api/crm/opportunities/route.test.ts
+++ b/src/app/api/crm/opportunities/route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const crmTenantFilterMock = vi.fn();
+
+const crmOpportunityFindManyMock = vi.fn();
+const crmOpportunityCreateMock = vi.fn();
+const crmAccountFindFirstMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/crm-scope", () => ({
+  crmTenantFilter: crmTenantFilterMock,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    crmOpportunity: {
+      findMany: crmOpportunityFindManyMock,
+      create: crmOpportunityCreateMock,
+    },
+    crmAccount: {
+      findFirst: crmAccountFindFirstMock,
+    },
+  },
+}));
+
+describe("CRM opportunities route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    crmTenantFilterMock.mockResolvedValue({ tenantId: "tenant-1" });
+  });
+
+  it("GET returns opportunities array contract", async () => {
+    crmOpportunityFindManyMock.mockResolvedValueOnce([
+      {
+        id: "opp-1",
+        name: "Pilot lane pricing",
+        stage: "QUALIFIED",
+        probability: 40,
+        estimatedRevenue: "15000",
+        currency: "USD",
+        closeDate: null,
+        nextStep: null,
+        nextStepDate: null,
+        ownerUserId: "user-1",
+        account: { id: "acc-1", name: "Acme" },
+        owner: { id: "user-1", name: "Alex", email: "alex@example.com" },
+      },
+    ]);
+    const { GET } = await import("./route");
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      opportunities: [
+        expect.objectContaining({
+          id: "opp-1",
+          stage: "QUALIFIED",
+          ownerUserId: "user-1",
+        }),
+      ],
+    });
+  });
+
+  it("POST returns 400 for missing required fields", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/opportunities", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ accountId: "acc-1" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "accountId and name are required.",
+    });
+    expect(crmOpportunityCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("POST returns 404 when account lookup fails", async () => {
+    crmAccountFindFirstMock.mockResolvedValueOnce(null);
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/opportunities", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ accountId: "acc-missing", name: "New opportunity" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Account not found." });
+  });
+
+  it("POST returns 201 with created opportunity contract", async () => {
+    crmAccountFindFirstMock.mockResolvedValueOnce({ id: "acc-1" });
+    crmOpportunityCreateMock.mockResolvedValueOnce({
+      id: "opp-2",
+      name: "Expansion",
+      stage: "IDENTIFIED",
+      accountId: "acc-1",
+      ownerUserId: "user-1",
+    });
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/crm/opportunities", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ accountId: "acc-1", name: "Expansion" }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({
+      opportunity: expect.objectContaining({
+        id: "opp-2",
+        accountId: "acc-1",
+        ownerUserId: "user-1",
+      }),
+    });
+  });
+});

--- a/src/app/api/crm/summary/route.test.ts
+++ b/src/app/api/crm/summary/route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const crmTenantFilterMock = vi.fn();
+
+const crmLeadCountMock = vi.fn();
+const crmAccountCountMock = vi.fn();
+const crmOpportunityCountMock = vi.fn();
+const crmActivityCountMock = vi.fn();
+const crmQuoteCountMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/crm-scope", () => ({
+  crmTenantFilter: crmTenantFilterMock,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    crmLead: { count: crmLeadCountMock },
+    crmAccount: { count: crmAccountCountMock },
+    crmOpportunity: { count: crmOpportunityCountMock },
+    crmActivity: { count: crmActivityCountMock },
+    crmQuote: { count: crmQuoteCountMock },
+  },
+}));
+
+describe("CRM summary route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    requireApiGrantMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    crmTenantFilterMock.mockResolvedValue({ tenantId: "tenant-1" });
+  });
+
+  it("returns 403 auth shape when no active actor", async () => {
+    getActorUserIdMock.mockResolvedValueOnce(null);
+    const { GET } = await import("./route");
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "No active user." });
+  });
+
+  it("returns stable aggregate summary shape", async () => {
+    crmLeadCountMock.mockResolvedValueOnce(4);
+    crmAccountCountMock.mockResolvedValueOnce(3);
+    crmOpportunityCountMock.mockResolvedValueOnce(2).mockResolvedValueOnce(1);
+    crmActivityCountMock.mockResolvedValueOnce(6).mockResolvedValueOnce(2);
+    crmQuoteCountMock.mockResolvedValueOnce(5);
+    const { GET } = await import("./route");
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      leads: 4,
+      accounts: 3,
+      openOpportunities: 2,
+      openActivities: 6,
+      openQuotes: 5,
+      staleOpportunities: 1,
+      overdueActivities: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add CRM route contract tests for accounts, opportunities, lead conversion, and summary endpoints.
- Assert stable status codes and response body shapes for success plus auth/validation failures.
- Keep behavior unchanged while strengthening API contract coverage for active CRM flows.

## Test plan
- [x] npm run lint
- [x] npx tsc --noEmit
- [x] npx vitest \"src/app/api/crm/accounts/route.test.ts\" \"src/app/api/crm/opportunities/route.test.ts\" \"src/app/api/crm/leads/[id]/convert/route.test.ts\" \"src/app/api/crm/summary/route.test.ts\"

Made with [Cursor](https://cursor.com)