### PR TITLE
test(invoice-audit): add route contract tests for invoice-audit APIs

### DIFF
--- a/src/app/api/invoice-audit/charge-aliases/[id]/route.test.ts
+++ b/src/app/api/invoice-audit/charge-aliases/[id]/route.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const parseInvoiceAuditRecordIdMock = vi.fn();
+const updateInvoiceChargeAliasForTenantMock = vi.fn();
+const parseCanonicalTokensFromBodyMock = vi.fn();
+const jsonFromInvoiceAuditErrorMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-audit-id", () => ({
+  parseInvoiceAuditRecordId: parseInvoiceAuditRecordIdMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-charge-aliases", () => ({
+  updateInvoiceChargeAliasForTenant: updateInvoiceChargeAliasForTenantMock,
+  parseCanonicalTokensFromBody: parseCanonicalTokensFromBodyMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/invoice-audit-api-error", () => ({
+  jsonFromInvoiceAuditError: jsonFromInvoiceAuditErrorMock,
+}));
+
+describe("Invoice charge-alias by-id route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    parseInvoiceAuditRecordIdMock.mockImplementation((raw: string) => (raw === "bad-id" ? null : raw));
+    parseCanonicalTokensFromBodyMock.mockReturnValue(["OCEAN"]);
+    jsonFromInvoiceAuditErrorMock.mockReturnValue(null);
+  });
+
+  it("returns parity error for invalid alias id", async () => {
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/charge-aliases/bad-id", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pattern: "Ocean" }),
+    });
+    const response = await PATCH(request, { params: Promise.resolve({ id: "bad-id" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid alias id." });
+  });
+
+  it("returns parity error for empty patch payload", async () => {
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/charge-aliases/alias-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const response = await PATCH(request, { params: Promise.resolve({ id: "alias-1" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "No updatable fields supplied." });
+  });
+
+  it("updates alias and returns alias shape", async () => {
+    updateInvoiceChargeAliasForTenantMock.mockResolvedValue({
+      id: "alias-1",
+      name: "Ocean",
+      pattern: "Ocean",
+      canonicalTokens: ["OCEAN"],
+      targetKind: null,
+      priority: 1,
+      active: true,
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/charge-aliases/alias-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ priority: 1 }),
+    });
+    const response = await PATCH(request, { params: Promise.resolve({ id: "alias-1" }) });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      alias: expect.objectContaining({
+        id: "alias-1",
+        priority: 1,
+      }),
+    });
+  });
+});

--- a/src/app/api/invoice-audit/charge-aliases/route.test.ts
+++ b/src/app/api/invoice-audit/charge-aliases/route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const listInvoiceChargeAliasesForTenantMock = vi.fn();
+const createInvoiceChargeAliasMock = vi.fn();
+const parseCanonicalTokensFromBodyMock = vi.fn();
+const jsonFromInvoiceAuditErrorMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-charge-aliases", () => ({
+  listInvoiceChargeAliasesForTenant: listInvoiceChargeAliasesForTenantMock,
+  createInvoiceChargeAlias: createInvoiceChargeAliasMock,
+  parseCanonicalTokensFromBody: parseCanonicalTokensFromBodyMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/invoice-audit-api-error", () => ({
+  jsonFromInvoiceAuditError: jsonFromInvoiceAuditErrorMock,
+}));
+
+describe("Invoice charge-aliases route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    parseCanonicalTokensFromBodyMock.mockReturnValue(["OCEAN"]);
+    jsonFromInvoiceAuditErrorMock.mockReturnValue(null);
+  });
+
+  it("GET returns aliases array", async () => {
+    listInvoiceChargeAliasesForTenantMock.mockResolvedValue([
+      {
+        id: "alias-1",
+        pattern: "Ocean",
+        canonicalTokens: ["OCEAN"],
+        targetKind: null,
+        priority: 0,
+        active: true,
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      },
+    ]);
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      aliases: [expect.objectContaining({ id: "alias-1", pattern: "Ocean" })],
+    });
+  });
+
+  it("POST returns parity error body for missing canonical tokens", async () => {
+    parseCanonicalTokensFromBodyMock.mockReturnValue([]);
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/charge-aliases", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pattern: "Ocean" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "canonicalTokens is required (non-empty array or newline/comma-separated string).",
+    });
+  });
+});

--- a/src/app/api/invoice-audit/intakes/[id]/route.test.ts
+++ b/src/app/api/invoice-audit/intakes/[id]/route.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const parseInvoiceAuditRecordIdMock = vi.fn();
+const parseInvoiceIntakePatchBodyMock = vi.fn();
+const getInvoiceIntakeForTenantMock = vi.fn();
+const setInvoiceIntakeRawSourceNotesMock = vi.fn();
+const setInvoiceIntakeReviewMock = vi.fn();
+const patchInvoiceIntakeReviewAndAccountingMock = vi.fn();
+const setInvoiceIntakeAccountingHandoffMock = vi.fn();
+const jsonFromInvoiceAuditErrorMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-audit-id", () => ({
+  parseInvoiceAuditRecordId: parseInvoiceAuditRecordIdMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-intake-patch-parse", () => ({
+  parseInvoiceIntakePatchBody: parseInvoiceIntakePatchBodyMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-intakes", () => ({
+  getInvoiceIntakeForTenant: getInvoiceIntakeForTenantMock,
+  setInvoiceIntakeRawSourceNotes: setInvoiceIntakeRawSourceNotesMock,
+  setInvoiceIntakeReview: setInvoiceIntakeReviewMock,
+  patchInvoiceIntakeReviewAndAccounting: patchInvoiceIntakeReviewAndAccountingMock,
+  setInvoiceIntakeAccountingHandoff: setInvoiceIntakeAccountingHandoffMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/invoice-audit-api-error", () => ({
+  jsonFromInvoiceAuditError: jsonFromInvoiceAuditErrorMock,
+}));
+
+describe("Invoice intake by-id route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    parseInvoiceAuditRecordIdMock.mockImplementation((raw: string) => (raw === "bad-id" ? null : raw));
+    jsonFromInvoiceAuditErrorMock.mockReturnValue(null);
+    parseInvoiceIntakePatchBodyMock.mockReturnValue({
+      ok: true,
+      value: {
+        hasReview: false,
+        hasAccounting: false,
+        hasRawSourceNotes: true,
+        rawSourceNotes: "ops note",
+        approvedForAccounting: null,
+      },
+    });
+  });
+
+  it("GET returns parity error body for invalid intake id", async () => {
+    const { GET } = await import("./route");
+    const response = await GET(new Request("http://localhost"), { params: Promise.resolve({ id: "bad-id" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid intake id." });
+  });
+
+  it("PATCH returns parity error body for invalid JSON", async () => {
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/intakes/intake-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: "intake-1" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid JSON body." });
+  });
+
+  it("PATCH updates notes and returns response shape parity", async () => {
+    getInvoiceIntakeForTenantMock.mockResolvedValue({
+      id: "intake-1",
+      reviewDecision: null,
+      reviewNote: null,
+      reviewedByUserId: null,
+      reviewedAt: null,
+      approvedForAccounting: null,
+      accountingApprovedByUserId: null,
+      accountingApprovedAt: null,
+      accountingApprovalNote: null,
+      createdByUserId: "user-1",
+      rawSourceNotes: "ops note",
+    });
+
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/intakes/intake-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rawSourceNotes: "ops note" }),
+    });
+    const response = await PATCH(request, { params: Promise.resolve({ id: "intake-1" }) });
+
+    expect(setInvoiceIntakeRawSourceNotesMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      invoiceIntakeId: "intake-1",
+      rawSourceNotes: "ops note",
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      intake: expect.objectContaining({
+        id: "intake-1",
+        rawSourceNotes: "ops note",
+        createdByUserId: "user-1",
+      }),
+    });
+  });
+});

--- a/src/app/api/invoice-audit/intakes/[id]/run-audit/route.test.ts
+++ b/src/app/api/invoice-audit/intakes/[id]/run-audit/route.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const parseInvoiceAuditRecordIdMock = vi.fn();
+const runInvoiceAuditForIntakeMock = vi.fn();
+const jsonFromInvoiceAuditErrorMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-audit-id", () => ({
+  parseInvoiceAuditRecordId: parseInvoiceAuditRecordIdMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-intakes", () => ({
+  runInvoiceAuditForIntake: runInvoiceAuditForIntakeMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/invoice-audit-api-error", () => ({
+  jsonFromInvoiceAuditError: jsonFromInvoiceAuditErrorMock,
+}));
+
+describe("Invoice intake run-audit route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    parseInvoiceAuditRecordIdMock.mockImplementation((raw: string) => (raw === "bad" ? null : raw));
+    jsonFromInvoiceAuditErrorMock.mockReturnValue(null);
+  });
+
+  it("returns parity error for invalid toleranceRuleId", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/intakes/intake-1/run-audit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ toleranceRuleId: "bad" }),
+    });
+    const response = await POST(request, { params: Promise.resolve({ id: "intake-1" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid toleranceRuleId." });
+  });
+
+  it("returns audited intake shape on success", async () => {
+    runInvoiceAuditForIntakeMock.mockResolvedValue({
+      id: "intake-1",
+      status: "AUDITED",
+      rollupOutcome: "GREEN",
+      greenLineCount: 1,
+      amberLineCount: 0,
+      redLineCount: 0,
+      unknownLineCount: 0,
+      auditRunError: null,
+      lastAuditAt: new Date("2026-04-20T00:00:00.000Z"),
+      lines: [],
+      auditResults: [],
+    });
+
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/intakes/intake-1/run-audit", {
+      method: "POST",
+    });
+    const response = await POST(request, { params: Promise.resolve({ id: "intake-1" }) });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      intake: expect.objectContaining({
+        id: "intake-1",
+        status: "AUDITED",
+        rollupOutcome: "GREEN",
+      }),
+    });
+  });
+});

--- a/src/app/api/invoice-audit/intakes/route.test.ts
+++ b/src/app/api/invoice-audit/intakes/route.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const listInvoiceIntakesForTenantMock = vi.fn();
+const createInvoiceIntakeWithLinesMock = vi.fn();
+const parseInvoiceAuditRecordIdMock = vi.fn();
+const jsonFromInvoiceAuditErrorMock = vi.fn();
+const serializeInvoiceIntakeListRowMock = vi.fn();
+const serializeBookingPricingSnapshotForIntakeApiMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-intakes", () => ({
+  listInvoiceIntakesForTenant: listInvoiceIntakesForTenantMock,
+  createInvoiceIntakeWithLines: createInvoiceIntakeWithLinesMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-audit-id", () => ({
+  parseInvoiceAuditRecordId: parseInvoiceAuditRecordIdMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/invoice-audit-api-error", () => ({
+  jsonFromInvoiceAuditError: jsonFromInvoiceAuditErrorMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/serialize", () => ({
+  serializeInvoiceIntakeListRow: serializeInvoiceIntakeListRowMock,
+  serializeBookingPricingSnapshotForIntakeApi: serializeBookingPricingSnapshotForIntakeApiMock,
+}));
+
+describe("Invoice audit intakes route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("user-1");
+    parseInvoiceAuditRecordIdMock.mockImplementation((raw: string) => raw);
+    jsonFromInvoiceAuditErrorMock.mockReturnValue(null);
+    serializeInvoiceIntakeListRowMock.mockImplementation((row: { id: string; status: string; currency: string }) => row);
+    serializeBookingPricingSnapshotForIntakeApiMock.mockImplementation((snapshot: { id: string }) => snapshot);
+  });
+
+  it("GET returns serialized intake list", async () => {
+    listInvoiceIntakesForTenantMock.mockResolvedValue([
+      {
+        id: "intake-1",
+        status: "PARSED",
+        externalInvoiceNo: null,
+        vendorLabel: null,
+        invoiceDate: null,
+        currency: "USD",
+        polCode: null,
+        podCode: null,
+        parseError: null,
+        parseWarnings: [],
+        auditRunError: null,
+        lastAuditAt: null,
+        rollupOutcome: null,
+        greenLineCount: 0,
+        amberLineCount: 0,
+        redLineCount: 0,
+        unknownLineCount: 0,
+        reviewDecision: null,
+        reviewNote: null,
+        reviewedByUserId: null,
+        reviewedAt: null,
+        approvedForAccounting: null,
+        accountingApprovedByUserId: null,
+        accountingApprovedAt: null,
+        accountingApprovalNote: null,
+        createdByUserId: "user-1",
+        receivedAt: new Date("2026-04-20T00:00:00.000Z"),
+        bookingPricingSnapshot: { id: "snap-1", sourceType: "RFQ", currency: "USD" },
+      },
+    ]);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      intakes: [
+        expect.objectContaining({
+          id: "intake-1",
+          status: "PARSED",
+          currency: "USD",
+        }),
+      ],
+    });
+  });
+
+  it("POST returns parity error body for invalid JSON", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/intakes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid JSON body." });
+  });
+
+  it("POST creates intake and keeps amount/quantity as strings", async () => {
+    createInvoiceIntakeWithLinesMock.mockResolvedValue({
+      id: "intake-2",
+      lines: [{ amount: 101.5, quantity: 2 }],
+      bookingPricingSnapshot: {
+        id: "snap-1",
+        sourceType: "RFQ",
+        sourceSummary: "quote",
+        currency: "USD",
+        totalEstimatedCost: 1000,
+        frozenAt: new Date("2026-04-20T00:00:00.000Z"),
+      },
+    });
+
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/intakes", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        bookingPricingSnapshotId: "snap-1",
+        lines: [{ lineNo: 1, rawDescription: "Ocean freight", currency: "USD", amount: "101.50", quantity: 2 }],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      intake: expect.objectContaining({
+        id: "intake-2",
+        lines: [expect.objectContaining({ amount: "101.5", quantity: "2" })],
+      }),
+    });
+  });
+});

--- a/src/app/api/invoice-audit/pricing-snapshot-options/route.test.ts
+++ b/src/app/api/invoice-audit/pricing-snapshot-options/route.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const findManyMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    bookingPricingSnapshot: {
+      findMany: findManyMock,
+    },
+  },
+}));
+
+describe("Invoice pricing-snapshot-options route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+  });
+
+  it("returns 404 parity body when tenant missing", async () => {
+    getDemoTenantMock.mockResolvedValue(null);
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Tenant not found." });
+  });
+
+  it("returns snapshots with totalEstimatedCost serialized as string", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        id: "snap-1",
+        sourceType: "RFQ",
+        sourceSummary: "Summary",
+        currency: "USD",
+        totalEstimatedCost: 1500.25,
+        frozenAt: new Date("2026-04-20T00:00:00.000Z"),
+      },
+    ]);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      snapshots: [
+        expect.objectContaining({
+          id: "snap-1",
+          totalEstimatedCost: "1500.25",
+        }),
+      ],
+    });
+  });
+});

--- a/src/app/api/invoice-audit/readiness/route.test.ts
+++ b/src/app/api/invoice-audit/readiness/route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const checkInvoiceAuditDatabaseSchemaMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-audit-db-readiness", () => ({
+  checkInvoiceAuditDatabaseSchema: checkInvoiceAuditDatabaseSchemaMock,
+  INVOICE_AUDIT_MIGRATION_SEQUENCE_HINT: ["m1", "m2"],
+}));
+
+describe("Invoice readiness route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+  });
+
+  it("passes refresh query as bypassCache=true", async () => {
+    checkInvoiceAuditDatabaseSchemaMock.mockResolvedValue({
+      ok: true,
+      issues: [],
+      appliedPrismaMigrations: ["m1"],
+      missingPrismaMigrations: [],
+      migrationHistoryNote: null,
+    });
+
+    const { GET } = await import("./route");
+    await GET(new Request("http://localhost/api/invoice-audit/readiness?refresh=true"));
+
+    expect(checkInvoiceAuditDatabaseSchemaMock).toHaveBeenCalledWith({ bypassCache: true });
+  });
+
+  it("returns 503 with expected body shape when readiness fails", async () => {
+    checkInvoiceAuditDatabaseSchemaMock.mockResolvedValue({
+      ok: false,
+      issues: [{ key: "invoice_intakes", message: "missing table" }],
+      appliedPrismaMigrations: [],
+      missingPrismaMigrations: ["m1"],
+      migrationHistoryNote: "run migrate",
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(new Request("http://localhost/api/invoice-audit/readiness"));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      ok: false,
+      issues: [{ key: "invoice_intakes", message: "missing table" }],
+      requiredMigrationsHint: ["m1", "m2"],
+      appliedPrismaMigrations: [],
+      missingPrismaMigrations: ["m1"],
+      migrationHistoryNote: "run migrate",
+    });
+  });
+});

--- a/src/app/api/invoice-audit/tolerance-rules/[id]/route.test.ts
+++ b/src/app/api/invoice-audit/tolerance-rules/[id]/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const parseInvoiceAuditRecordIdMock = vi.fn();
+const updateToleranceRuleForTenantMock = vi.fn();
+const jsonFromInvoiceAuditErrorMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/invoice-audit/invoice-audit-id", () => ({
+  parseInvoiceAuditRecordId: parseInvoiceAuditRecordIdMock,
+}));
+
+vi.mock("@/lib/invoice-audit/tolerance-rules", () => ({
+  updateToleranceRuleForTenant: updateToleranceRuleForTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/invoice-audit-api-error", () => ({
+  jsonFromInvoiceAuditError: jsonFromInvoiceAuditErrorMock,
+}));
+
+describe("Invoice tolerance-rule by-id route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    parseInvoiceAuditRecordIdMock.mockImplementation((raw: string) => (raw === "bad-id" ? null : raw));
+    jsonFromInvoiceAuditErrorMock.mockReturnValue(null);
+  });
+
+  it("returns parity error for invalid rule id", async () => {
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/tolerance-rules/bad-id", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Default" }),
+    });
+    const response = await PATCH(request, { params: Promise.resolve({ id: "bad-id" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid rule id." });
+  });
+
+  it("returns parity error when no updatable fields supplied", async () => {
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/tolerance-rules/rule-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const response = await PATCH(request, { params: Promise.resolve({ id: "rule-1" }) });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "No updatable fields supplied." });
+  });
+
+  it("updates rule and returns rule shape", async () => {
+    updateToleranceRuleForTenantMock.mockResolvedValue({
+      id: "rule-1",
+      name: "Default",
+      priority: 0,
+      active: true,
+      amountAbsTolerance: null,
+      percentTolerance: null,
+      currencyScope: null,
+      categoryScope: null,
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+
+    const { PATCH } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/tolerance-rules/rule-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ active: true }),
+    });
+    const response = await PATCH(request, { params: Promise.resolve({ id: "rule-1" }) });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      rule: expect.objectContaining({
+        id: "rule-1",
+        name: "Default",
+      }),
+    });
+  });
+});

--- a/src/app/api/invoice-audit/tolerance-rules/route.test.ts
+++ b/src/app/api/invoice-audit/tolerance-rules/route.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireApiGrantMock = vi.fn();
+const getDemoTenantMock = vi.fn();
+const guardInvoiceAuditSchemaMock = vi.fn();
+const listToleranceRulesForTenantMock = vi.fn();
+const createToleranceRuleMock = vi.fn();
+const jsonFromInvoiceAuditErrorMock = vi.fn();
+
+vi.mock("@/lib/authz", () => ({
+  requireApiGrant: requireApiGrantMock,
+}));
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/guard-invoice-audit-schema", () => ({
+  guardInvoiceAuditSchema: guardInvoiceAuditSchemaMock,
+}));
+
+vi.mock("@/lib/invoice-audit/tolerance-rules", () => ({
+  listToleranceRulesForTenant: listToleranceRulesForTenantMock,
+  createToleranceRule: createToleranceRuleMock,
+}));
+
+vi.mock("@/app/api/invoice-audit/_lib/invoice-audit-api-error", () => ({
+  jsonFromInvoiceAuditError: jsonFromInvoiceAuditErrorMock,
+}));
+
+describe("Invoice tolerance-rules route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireApiGrantMock.mockResolvedValue(null);
+    guardInvoiceAuditSchemaMock.mockResolvedValue(null);
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    jsonFromInvoiceAuditErrorMock.mockReturnValue(null);
+  });
+
+  it("GET returns rules array", async () => {
+    listToleranceRulesForTenantMock.mockResolvedValue([
+      {
+        id: "rule-1",
+        name: "Default",
+        priority: 0,
+        active: true,
+        amountAbsTolerance: null,
+        percentTolerance: null,
+        currencyScope: null,
+        categoryScope: null,
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      },
+    ]);
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      rules: [expect.objectContaining({ id: "rule-1", name: "Default" })],
+    });
+  });
+
+  it("POST returns parity error body when name missing", async () => {
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/invoice-audit/tolerance-rules", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: " " }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "name is required." });
+  });
+});


### PR DESCRIPTION
## Summary
- add route contract tests for all invoice-audit API handlers under `src/app/api/invoice-audit/**`
- cover success and failure parity assertions (status and response body shape) for each route family
- keep runtime behavior unchanged by limiting the diff to new test files only

## Test plan
- [x] `npm run check:invoice-audit`
- [x] `npx vitest run src/app/api/invoice-audit`
- [x] `npx tsc --noEmit` *(currently fails due to pre-existing out-of-scope Control Tower typing issues)*

Made with [Cursor](https://cursor.com)