### PR TITLE
refactor(control-tower): decompose workbench into stable units

### DIFF
--- a/src/components/control-tower-workbench.tsx
+++ b/src/components/control-tower-workbench.tsx
@@ -13,7 +13,6 @@ import {
   readWorkbenchUrlState,
   type WorkbenchUrlState,
 } from "@/lib/control-tower/workbench-url-sync";
-import type { CtMilestoneSummary } from "@/lib/control-tower/milestone-summary";
 import {
   WORKBENCH_COLUMN_LABELS,
   WORKBENCH_COLUMN_STORAGE_KEY,
@@ -23,79 +22,14 @@ import {
   workbenchVisibleColumnCount,
   type WorkbenchTogglableColumn,
 } from "@/lib/control-tower/workbench-column-prefs";
-
-type Row = {
-  id: string;
-  shipmentNo: string | null;
-  status: string;
-  transportMode: string | null;
-  trackingNo: string | null;
-  carrier: string | null;
-  carrierSupplierId: string | null;
-  orderId: string;
-  orderNumber: string;
-  supplierId: string | null;
-  supplierName: string | null;
-  externalOrderRef?: string | null;
-  shipmentSource?: "PO" | "UNLINKED";
-  customerCrmAccountId: string | null;
-  customerCrmAccountName: string | null;
-  originCode: string | null;
-  destinationCode: string | null;
-  etd: string | null;
-  eta: string | null;
-  latestEta: string | null;
-  receivedAt: string | null;
-  routeProgressPct: number | null;
-  nextAction: string | null;
-  bookingStatus?: string | null;
-  bookingSlaBreached?: boolean;
-  bookingSentAt?: string | null;
-  bookingConfirmSlaDueAt?: string | null;
-  quantityRef: string | null;
-  weightKgRef: string | null;
-  cbmRef: string | null;
-  updatedAt: string;
-  latestMilestone: { code: string; hasActual: boolean } | null;
-  trackingMilestoneSummary: CtMilestoneSummary | null;
-  dispatchOwner: { id: string; name: string } | null;
-  openQueueCounts: { openAlerts: number; openExceptions: number };
-};
-
-type HealthState = "good" | "at_risk" | "delayed" | "missing_data";
-
-function classifyShipmentHealth(r: Row, nowMs: number): HealthState {
-  if (r.bookingSlaBreached) return "at_risk";
-  const na = r.nextAction || "";
-  if (na.startsWith("Escalate booking")) return "at_risk";
-  if (na.startsWith("Send booking")) return "missing_data";
-  const etaIso = r.latestEta || r.eta;
-  const etaMs = etaIso ? new Date(etaIso).getTime() : Number.NaN;
-  const hasTracking = Boolean(r.trackingMilestoneSummary?.next || (r.trackingMilestoneSummary?.openCount ?? 0) > 0);
-  const hasRoutePlan = Boolean(r.nextAction);
-  if (!hasTracking && !hasRoutePlan) return "missing_data";
-  if (r.receivedAt && Number.isFinite(etaMs)) {
-    return new Date(r.receivedAt).getTime() <= etaMs ? "good" : "delayed";
-  }
-  if (Number.isFinite(etaMs) && etaMs < nowMs) return "delayed";
-  if ((r.openQueueCounts?.openAlerts ?? 0) > 0 || (r.openQueueCounts?.openExceptions ?? 0) > 0) return "at_risk";
-  if (r.trackingMilestoneSummary?.next?.isLate) return "at_risk";
-  return "good";
-}
-
-function healthBadgeClass(health: HealthState): string {
-  if (health === "good") return "border-emerald-200 bg-emerald-50 text-emerald-900";
-  if (health === "at_risk") return "border-amber-200 bg-amber-50 text-amber-950";
-  if (health === "delayed") return "border-rose-200 bg-rose-50 text-rose-900";
-  return "border-zinc-300 bg-zinc-100 text-zinc-700";
-}
-
-function healthLabel(health: HealthState): string {
-  if (health === "good") return "On-time";
-  if (health === "at_risk") return "At risk";
-  if (health === "delayed") return "Delayed";
-  return "Missing plan/tracking";
-}
+import { buildWorkbenchCsv } from "@/components/control-tower-workbench/csv";
+import { classifyShipmentHealth, healthBadgeClass, healthLabel } from "@/components/control-tower-workbench/health";
+import {
+  createRouteActionCounts,
+  ROUTE_ACTION_OPTIONS,
+} from "@/components/control-tower-workbench/route-actions";
+import type { ShipmentHealthState as HealthState, WorkbenchRow as Row } from "@/components/control-tower-workbench/types";
+import type { RouteActionName } from "@/components/control-tower-workbench/route-actions";
 
 function ActionTooltipButton({
   disabled,
@@ -708,41 +642,8 @@ function ControlTowerWorkbenchInner({
     [],
   );
   const modeOptions = useMemo(() => ["", "OCEAN", "AIR", "ROAD", "RAIL"], []);
-  const routeActionOptions = useMemo(
-    () => [
-      "",
-      "Send booking",
-      "Await booking",
-      "Escalate booking",
-      "Plan leg",
-      "Mark departure",
-      "Record arrival",
-      "Route complete",
-    ],
-    [],
-  );
-  const routeActionCounts = useMemo(() => {
-    const out: Record<string, number> = {
-      "Send booking": 0,
-      "Await booking": 0,
-      "Escalate booking": 0,
-      "Plan leg": 0,
-      "Mark departure": 0,
-      "Record arrival": 0,
-      "Route complete": 0,
-    };
-    for (const r of rows) {
-      const action = r.nextAction || "";
-      if (action.startsWith("Send booking")) out["Send booking"] += 1;
-      else if (action.startsWith("Await booking")) out["Await booking"] += 1;
-      else if (action.startsWith("Escalate booking")) out["Escalate booking"] += 1;
-      else if (action.startsWith("Plan leg")) out["Plan leg"] += 1;
-      else if (action.startsWith("Mark departure")) out["Mark departure"] += 1;
-      else if (action.startsWith("Record arrival")) out["Record arrival"] += 1;
-      else if (action.startsWith("Route complete")) out["Route complete"] += 1;
-    }
-    return out;
-  }, [rows]);
+  const routeActionOptions = useMemo(() => [...ROUTE_ACTION_OPTIONS], []);
+  const routeActionCounts = useMemo(() => createRouteActionCounts(rows), [rows]);
   const ownerChoices = useMemo(() => {
     const m = new Map<string, string>();
     for (const r of rows) {
@@ -776,99 +677,15 @@ function ControlTowerWorkbenchInner({
   }, [filteredRows, healthQuickFilter]);
 
   const exportCsv = useCallback(() => {
-    const esc = (v: string) => `"${v.replace(/"/g, '""')}"`;
-    const colOn = (k: WorkbenchTogglableColumn) => {
-      if (k === "owner" && restrictedView) return false;
-      return colVis[k] !== false;
-    };
-
-    const hs: string[] = ["shipmentId", "orderNumber", "shipmentNo"];
-    if (colOn("status")) hs.push("status");
-    if (colOn("mode")) hs.push("mode");
-    if (colOn("health")) hs.push("health");
-    if (colOn("customer")) hs.push("customer");
-    if (colOn("lane")) hs.push("lane");
-    if (colOn("eta")) hs.push("eta");
-    if (colOn("ataDelay")) {
-      hs.push("ata", "etaVsAtaDays");
-    }
-    if (colOn("qtyWt")) {
-      hs.push("quantityRef", "weightKgRef", "cbmRef");
-    }
-    if (colOn("owner")) {
-      hs.push("owner", "openAlerts", "openExceptions");
-    }
-    if (colOn("route")) hs.push("routeProgressPct");
-    if (colOn("nextAction")) hs.push("nextAction");
-    if (colOn("milestone")) hs.push("milestoneSummary");
-    if (colOn("updated")) hs.push("updatedAt");
-
-    const rowLine = (r: Row) => {
-      const cells: string[] = [esc(r.id), esc(r.orderNumber), esc(r.shipmentNo || "")];
-      if (colOn("status")) cells.push(esc(r.status));
-      if (colOn("mode")) cells.push(esc(r.transportMode || ""));
-      if (colOn("health")) {
-        const health = classifyShipmentHealth(r, Date.now());
-        cells.push(esc(healthLabel(health)));
-      }
-      if (colOn("customer")) {
-        cells.push(esc(r.customerCrmAccountName || r.customerCrmAccountId || ""));
-      }
-      if (colOn("lane")) {
-        cells.push(esc(`${r.originCode || ""} → ${r.destinationCode || ""}`));
-      }
-      if (colOn("eta")) {
-        cells.push(esc(r.eta || r.latestEta || ""));
-      }
-      if (colOn("ataDelay")) {
-        cells.push(esc(r.receivedAt || ""));
-        cells.push(
-          esc(
-            (() => {
-              const etaIso = r.latestEta || r.eta;
-              if (!etaIso || !r.receivedAt) return "";
-              const deltaMs = new Date(r.receivedAt).getTime() - new Date(etaIso).getTime();
-              return (deltaMs / 86_400_000).toFixed(1);
-            })(),
-          ),
-        );
-      }
-      if (colOn("qtyWt")) {
-        cells.push(esc(r.quantityRef || ""));
-        cells.push(esc(r.weightKgRef || ""));
-        cells.push(esc(r.cbmRef || ""));
-      }
-      if (colOn("owner")) {
-        cells.push(esc(r.dispatchOwner?.name || "Unassigned"));
-        cells.push(esc(String(r.openQueueCounts?.openAlerts ?? 0)));
-        cells.push(esc(String(r.openQueueCounts?.openExceptions ?? 0)));
-      }
-      if (colOn("route")) {
-        cells.push(esc(r.routeProgressPct == null ? "" : String(r.routeProgressPct)));
-      }
-      if (colOn("nextAction")) cells.push(esc(r.nextAction || ""));
-      if (colOn("milestone")) {
-        const parts: string[] = [];
-        if (r.latestMilestone) {
-          parts.push(`${r.latestMilestone.code}${r.latestMilestone.hasActual ? " ✓" : ""}`);
-        }
-        if (r.trackingMilestoneSummary?.next?.code) {
-          parts.push(`next:${r.trackingMilestoneSummary.next.code}`);
-        }
-        cells.push(esc(parts.length ? parts.join("; ") : ""));
-      }
-      if (colOn("updated")) cells.push(esc(r.updatedAt));
-      return cells.join(",");
-    };
-
-    const meta =
-      listTruncated && listLimit != null
-        ? [
-            `# control-tower-workbench export: list truncated at ${listLimit} rows for current filters; more shipments may match — narrow filters and re-export.`,
-          ]
-        : [];
-    const lines = [...meta, hs.join(","), ...chipFilteredRows.map(rowLine)];
-    const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+    const csv = buildWorkbenchCsv({
+      rows: chipFilteredRows,
+      colVis,
+      restrictedView,
+      listTruncated,
+      listLimit,
+      nowMs: Date.now(),
+    });
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -1325,7 +1142,7 @@ function ControlTowerWorkbenchInner({
           Any ({rows.length})
         </button>
         {routeActionOptions
-          .filter((o) => o)
+          .filter((o): o is RouteActionName => Boolean(o))
           .map((opt) => (
             <button
               key={opt}

--- a/src/components/control-tower-workbench/csv.test.ts
+++ b/src/components/control-tower-workbench/csv.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWorkbenchCsv } from "@/components/control-tower-workbench/csv";
+import type { WorkbenchRow } from "@/components/control-tower-workbench/types";
+import { defaultWorkbenchColumnVisibility } from "@/lib/control-tower/workbench-column-prefs";
+
+const row: WorkbenchRow = {
+  id: "ship-1",
+  shipmentNo: "ASN-1",
+  status: "IN_TRANSIT",
+  transportMode: "OCEAN",
+  trackingNo: null,
+  carrier: null,
+  carrierSupplierId: null,
+  orderId: "order-1",
+  orderNumber: "PO-1",
+  supplierId: null,
+  supplierName: null,
+  customerCrmAccountId: "acc-1",
+  customerCrmAccountName: "ACME",
+  originCode: "CNSHA",
+  destinationCode: "USLAX",
+  etd: null,
+  eta: "2026-04-20T00:00:00.000Z",
+  latestEta: null,
+  receivedAt: "2026-04-21T00:00:00.000Z",
+  routeProgressPct: 80,
+  nextAction: "Mark departure",
+  quantityRef: "100",
+  weightKgRef: "2300",
+  cbmRef: "9.5",
+  updatedAt: "2026-04-20T12:00:00.000Z",
+  latestMilestone: { code: "BOOKED", hasActual: true },
+  trackingMilestoneSummary: {
+    openCount: 1,
+    lateCount: 0,
+    next: { code: "DEPARTED", label: null, dueAt: null, isLate: false },
+  },
+  dispatchOwner: { id: "u1", name: "Alex" },
+  openQueueCounts: { openAlerts: 1, openExceptions: 2 },
+};
+
+describe("buildWorkbenchCsv", () => {
+  it("prepends truncation metadata and includes visible columns", () => {
+    const csv = buildWorkbenchCsv({
+      rows: [row],
+      colVis: defaultWorkbenchColumnVisibility(),
+      restrictedView: false,
+      listTruncated: true,
+      listLimit: 150,
+      nowMs: Date.parse("2026-04-22T00:00:00.000Z"),
+    });
+
+    const [meta, header, firstRow] = csv.split("\n");
+    expect(meta).toContain("list truncated at 150 rows");
+    expect(header).toContain("health");
+    expect(header).toContain("owner");
+    expect(firstRow).toContain('"Delayed"');
+    expect(firstRow).toContain('"BOOKED ✓; next:DEPARTED"');
+  });
+
+  it("omits owner columns in restricted view", () => {
+    const csv = buildWorkbenchCsv({
+      rows: [row],
+      colVis: defaultWorkbenchColumnVisibility(),
+      restrictedView: true,
+      listTruncated: false,
+      listLimit: null,
+      nowMs: Date.parse("2026-04-20T00:00:00.000Z"),
+    });
+
+    const [header] = csv.split("\n");
+    expect(header).not.toContain("owner");
+    expect(header).not.toContain("openAlerts");
+  });
+});

--- a/src/components/control-tower-workbench/csv.ts
+++ b/src/components/control-tower-workbench/csv.ts
@@ -1,0 +1,111 @@
+import { classifyShipmentHealth, healthLabel } from "@/components/control-tower-workbench/health";
+import type { WorkbenchRow } from "@/components/control-tower-workbench/types";
+import type { WorkbenchTogglableColumn } from "@/lib/control-tower/workbench-column-prefs";
+
+type CsvOptions = {
+  rows: WorkbenchRow[];
+  colVis: Record<WorkbenchTogglableColumn, boolean>;
+  restrictedView: boolean;
+  listTruncated: boolean;
+  listLimit: number | null;
+  nowMs: number;
+};
+
+function csvEscape(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+export function buildWorkbenchCsv({
+  rows,
+  colVis,
+  restrictedView,
+  listTruncated,
+  listLimit,
+  nowMs,
+}: CsvOptions): string {
+  const colOn = (column: WorkbenchTogglableColumn): boolean => {
+    if (column === "owner" && restrictedView) return false;
+    return colVis[column] !== false;
+  };
+
+  const headers: string[] = ["shipmentId", "orderNumber", "shipmentNo"];
+  if (colOn("status")) headers.push("status");
+  if (colOn("mode")) headers.push("mode");
+  if (colOn("health")) headers.push("health");
+  if (colOn("customer")) headers.push("customer");
+  if (colOn("lane")) headers.push("lane");
+  if (colOn("eta")) headers.push("eta");
+  if (colOn("ataDelay")) headers.push("ata", "etaVsAtaDays");
+  if (colOn("qtyWt")) headers.push("quantityRef", "weightKgRef", "cbmRef");
+  if (colOn("owner")) headers.push("owner", "openAlerts", "openExceptions");
+  if (colOn("route")) headers.push("routeProgressPct");
+  if (colOn("nextAction")) headers.push("nextAction");
+  if (colOn("milestone")) headers.push("milestoneSummary");
+  if (colOn("updated")) headers.push("updatedAt");
+
+  const csvRows = rows.map((row) => {
+    const cells: string[] = [csvEscape(row.id), csvEscape(row.orderNumber), csvEscape(row.shipmentNo || "")];
+    if (colOn("status")) cells.push(csvEscape(row.status));
+    if (colOn("mode")) cells.push(csvEscape(row.transportMode || ""));
+    if (colOn("health")) {
+      const health = classifyShipmentHealth(row, nowMs);
+      cells.push(csvEscape(healthLabel(health)));
+    }
+    if (colOn("customer")) {
+      cells.push(csvEscape(row.customerCrmAccountName || row.customerCrmAccountId || ""));
+    }
+    if (colOn("lane")) {
+      cells.push(csvEscape(`${row.originCode || ""} → ${row.destinationCode || ""}`));
+    }
+    if (colOn("eta")) {
+      cells.push(csvEscape(row.eta || row.latestEta || ""));
+    }
+    if (colOn("ataDelay")) {
+      cells.push(csvEscape(row.receivedAt || ""));
+      cells.push(
+        csvEscape(
+          (() => {
+            const etaIso = row.latestEta || row.eta;
+            if (!etaIso || !row.receivedAt) return "";
+            const deltaMs = new Date(row.receivedAt).getTime() - new Date(etaIso).getTime();
+            return (deltaMs / 86_400_000).toFixed(1);
+          })(),
+        ),
+      );
+    }
+    if (colOn("qtyWt")) {
+      cells.push(csvEscape(row.quantityRef || ""));
+      cells.push(csvEscape(row.weightKgRef || ""));
+      cells.push(csvEscape(row.cbmRef || ""));
+    }
+    if (colOn("owner")) {
+      cells.push(csvEscape(row.dispatchOwner?.name || "Unassigned"));
+      cells.push(csvEscape(String(row.openQueueCounts?.openAlerts ?? 0)));
+      cells.push(csvEscape(String(row.openQueueCounts?.openExceptions ?? 0)));
+    }
+    if (colOn("route")) {
+      cells.push(csvEscape(row.routeProgressPct == null ? "" : String(row.routeProgressPct)));
+    }
+    if (colOn("nextAction")) cells.push(csvEscape(row.nextAction || ""));
+    if (colOn("milestone")) {
+      const parts: string[] = [];
+      if (row.latestMilestone) {
+        parts.push(`${row.latestMilestone.code}${row.latestMilestone.hasActual ? " ✓" : ""}`);
+      }
+      if (row.trackingMilestoneSummary?.next?.code) {
+        parts.push(`next:${row.trackingMilestoneSummary.next.code}`);
+      }
+      cells.push(csvEscape(parts.length > 0 ? parts.join("; ") : ""));
+    }
+    if (colOn("updated")) cells.push(csvEscape(row.updatedAt));
+    return cells.join(",");
+  });
+
+  const metadata =
+    listTruncated && listLimit != null
+      ? [
+          `# control-tower-workbench export: list truncated at ${listLimit} rows for current filters; more shipments may match — narrow filters and re-export.`,
+        ]
+      : [];
+  return [...metadata, headers.join(","), ...csvRows].join("\n");
+}

--- a/src/components/control-tower-workbench/health.test.ts
+++ b/src/components/control-tower-workbench/health.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyShipmentHealth, healthLabel } from "@/components/control-tower-workbench/health";
+import type { WorkbenchRow } from "@/components/control-tower-workbench/types";
+
+function buildRow(overrides: Partial<WorkbenchRow> = {}): WorkbenchRow {
+  return {
+    id: "ship-1",
+    shipmentNo: null,
+    status: "IN_TRANSIT",
+    transportMode: "OCEAN",
+    trackingNo: null,
+    carrier: null,
+    carrierSupplierId: null,
+    orderId: "order-1",
+    orderNumber: "PO-1",
+    supplierId: null,
+    supplierName: null,
+    customerCrmAccountId: null,
+    customerCrmAccountName: null,
+    originCode: null,
+    destinationCode: null,
+    etd: null,
+    eta: "2026-04-20T12:00:00.000Z",
+    latestEta: null,
+    receivedAt: null,
+    routeProgressPct: 50,
+    nextAction: "Plan leg",
+    quantityRef: null,
+    weightKgRef: null,
+    cbmRef: null,
+    updatedAt: "2026-04-20T12:00:00.000Z",
+    latestMilestone: null,
+    trackingMilestoneSummary: { openCount: 0, lateCount: 0, next: null },
+    dispatchOwner: null,
+    openQueueCounts: { openAlerts: 0, openExceptions: 0 },
+    ...overrides,
+  };
+}
+
+describe("classifyShipmentHealth", () => {
+  it("marks send-booking rows as missing data", () => {
+    const row = buildRow({ nextAction: "Send booking" });
+    expect(classifyShipmentHealth(row, Date.now())).toBe("missing_data");
+    expect(healthLabel("missing_data")).toBe("Missing plan/tracking");
+  });
+
+  it("marks late deliveries as delayed", () => {
+    const row = buildRow({
+      eta: "2026-04-10T00:00:00.000Z",
+      receivedAt: "2026-04-12T00:00:00.000Z",
+    });
+    expect(classifyShipmentHealth(row, Date.now())).toBe("delayed");
+  });
+
+  it("marks queue alerts as at risk", () => {
+    const row = buildRow({
+      openQueueCounts: { openAlerts: 2, openExceptions: 0 },
+      trackingMilestoneSummary: { openCount: 2, lateCount: 0, next: null },
+    });
+    expect(classifyShipmentHealth(row, Date.now())).toBe("at_risk");
+  });
+});

--- a/src/components/control-tower-workbench/health.ts
+++ b/src/components/control-tower-workbench/health.ts
@@ -1,0 +1,34 @@
+import type { ShipmentHealthState, WorkbenchRow } from "@/components/control-tower-workbench/types";
+
+export function classifyShipmentHealth(row: WorkbenchRow, nowMs: number): ShipmentHealthState {
+  if (row.bookingSlaBreached) return "at_risk";
+  const nextAction = row.nextAction || "";
+  if (nextAction.startsWith("Escalate booking")) return "at_risk";
+  if (nextAction.startsWith("Send booking")) return "missing_data";
+  const etaIso = row.latestEta || row.eta;
+  const etaMs = etaIso ? new Date(etaIso).getTime() : Number.NaN;
+  const hasTracking = Boolean(row.trackingMilestoneSummary?.next || (row.trackingMilestoneSummary?.openCount ?? 0) > 0);
+  const hasRoutePlan = Boolean(row.nextAction);
+  if (!hasTracking && !hasRoutePlan) return "missing_data";
+  if (row.receivedAt && Number.isFinite(etaMs)) {
+    return new Date(row.receivedAt).getTime() <= etaMs ? "good" : "delayed";
+  }
+  if (Number.isFinite(etaMs) && etaMs < nowMs) return "delayed";
+  if ((row.openQueueCounts?.openAlerts ?? 0) > 0 || (row.openQueueCounts?.openExceptions ?? 0) > 0) return "at_risk";
+  if (row.trackingMilestoneSummary?.next?.isLate) return "at_risk";
+  return "good";
+}
+
+export function healthBadgeClass(health: ShipmentHealthState): string {
+  if (health === "good") return "border-emerald-200 bg-emerald-50 text-emerald-900";
+  if (health === "at_risk") return "border-amber-200 bg-amber-50 text-amber-950";
+  if (health === "delayed") return "border-rose-200 bg-rose-50 text-rose-900";
+  return "border-zinc-300 bg-zinc-100 text-zinc-700";
+}
+
+export function healthLabel(health: ShipmentHealthState): string {
+  if (health === "good") return "On-time";
+  if (health === "at_risk") return "At risk";
+  if (health === "delayed") return "Delayed";
+  return "Missing plan/tracking";
+}

--- a/src/components/control-tower-workbench/route-actions.test.ts
+++ b/src/components/control-tower-workbench/route-actions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouteActionCounts } from "@/components/control-tower-workbench/route-actions";
+import type { WorkbenchRow } from "@/components/control-tower-workbench/types";
+
+const baseRow: WorkbenchRow = {
+  id: "ship-1",
+  shipmentNo: null,
+  status: "IN_TRANSIT",
+  transportMode: "OCEAN",
+  trackingNo: null,
+  carrier: null,
+  carrierSupplierId: null,
+  orderId: "order-1",
+  orderNumber: "PO-1",
+  supplierId: null,
+  supplierName: null,
+  customerCrmAccountId: null,
+  customerCrmAccountName: null,
+  originCode: null,
+  destinationCode: null,
+  etd: null,
+  eta: null,
+  latestEta: null,
+  receivedAt: null,
+  routeProgressPct: 30,
+  nextAction: null,
+  quantityRef: null,
+  weightKgRef: null,
+  cbmRef: null,
+  updatedAt: "2026-04-20T12:00:00.000Z",
+  latestMilestone: null,
+  trackingMilestoneSummary: null,
+  dispatchOwner: null,
+  openQueueCounts: { openAlerts: 0, openExceptions: 0 },
+};
+
+describe("createRouteActionCounts", () => {
+  it("counts prefix-matched actions consistently", () => {
+    const counts = createRouteActionCounts([
+      { ...baseRow, id: "1", nextAction: "Send booking now" },
+      { ...baseRow, id: "2", nextAction: "Send booking follow-up" },
+      { ...baseRow, id: "3", nextAction: "Await booking confirmation" },
+      { ...baseRow, id: "4", nextAction: "Mark departure terminal gate out" },
+      { ...baseRow, id: "5", nextAction: "Unknown action" },
+    ]);
+
+    expect(counts["Send booking"]).toBe(2);
+    expect(counts["Await booking"]).toBe(1);
+    expect(counts["Mark departure"]).toBe(1);
+    expect(counts["Escalate booking"]).toBe(0);
+  });
+});

--- a/src/components/control-tower-workbench/route-actions.ts
+++ b/src/components/control-tower-workbench/route-actions.ts
@@ -1,0 +1,37 @@
+import type { WorkbenchRow } from "@/components/control-tower-workbench/types";
+
+export const ROUTE_ACTION_OPTIONS = [
+  "",
+  "Send booking",
+  "Await booking",
+  "Escalate booking",
+  "Plan leg",
+  "Mark departure",
+  "Record arrival",
+  "Route complete",
+] as const;
+
+export type RouteActionName = Exclude<(typeof ROUTE_ACTION_OPTIONS)[number], "">;
+
+export function createRouteActionCounts(rows: WorkbenchRow[]): Record<RouteActionName, number> {
+  const counts: Record<RouteActionName, number> = {
+    "Send booking": 0,
+    "Await booking": 0,
+    "Escalate booking": 0,
+    "Plan leg": 0,
+    "Mark departure": 0,
+    "Record arrival": 0,
+    "Route complete": 0,
+  };
+  for (const row of rows) {
+    const action = row.nextAction || "";
+    if (action.startsWith("Send booking")) counts["Send booking"] += 1;
+    else if (action.startsWith("Await booking")) counts["Await booking"] += 1;
+    else if (action.startsWith("Escalate booking")) counts["Escalate booking"] += 1;
+    else if (action.startsWith("Plan leg")) counts["Plan leg"] += 1;
+    else if (action.startsWith("Mark departure")) counts["Mark departure"] += 1;
+    else if (action.startsWith("Record arrival")) counts["Record arrival"] += 1;
+    else if (action.startsWith("Route complete")) counts["Route complete"] += 1;
+  }
+  return counts;
+}

--- a/src/components/control-tower-workbench/types.ts
+++ b/src/components/control-tower-workbench/types.ts
@@ -1,0 +1,41 @@
+import type { CtMilestoneSummary } from "@/lib/control-tower/milestone-summary";
+
+export type WorkbenchRow = {
+  id: string;
+  shipmentNo: string | null;
+  status: string;
+  transportMode: string | null;
+  trackingNo: string | null;
+  carrier: string | null;
+  carrierSupplierId: string | null;
+  orderId: string;
+  orderNumber: string;
+  supplierId: string | null;
+  supplierName: string | null;
+  externalOrderRef?: string | null;
+  shipmentSource?: "PO" | "UNLINKED";
+  customerCrmAccountId: string | null;
+  customerCrmAccountName: string | null;
+  originCode: string | null;
+  destinationCode: string | null;
+  etd: string | null;
+  eta: string | null;
+  latestEta: string | null;
+  receivedAt: string | null;
+  routeProgressPct: number | null;
+  nextAction: string | null;
+  bookingStatus?: string | null;
+  bookingSlaBreached?: boolean;
+  bookingSentAt?: string | null;
+  bookingConfirmSlaDueAt?: string | null;
+  quantityRef: string | null;
+  weightKgRef: string | null;
+  cbmRef: string | null;
+  updatedAt: string;
+  latestMilestone: { code: string; hasActual: boolean } | null;
+  trackingMilestoneSummary: CtMilestoneSummary | null;
+  dispatchOwner: { id: string; name: string } | null;
+  openQueueCounts: { openAlerts: number; openExceptions: number };
+};
+
+export type ShipmentHealthState = "good" | "at_risk" | "delayed" | "missing_data";


### PR DESCRIPTION
## Summary
- Extract workbench domain seams into stable units: health classification, route action counting, CSV export, and shared row/types.
- Keep the main workbench container behavior and UX unchanged by wiring existing logic through the extracted interfaces.
- Add targeted unit tests around extracted seams to prevent regressions.

## Test plan
- [x] npm run lint
- [x] npx tsc --noEmit
- [x] npx vitest run src/components/control-tower-workbench/*.test.ts

Made with [Cursor](https://cursor.com)