### PR TITLE
M1: API Hub route-contract coverage + phase alignment

### DIFF
--- a/prisma/migrations/20260420194500_apihub_connector_auth_config_model/migration.sql
+++ b/prisma/migrations/20260420194500_apihub_connector_auth_config_model/migration.sql
@@ -1,0 +1,6 @@
+-- API hub M1: connector auth/config metadata model (no secrets).
+
+ALTER TABLE "ApiHubConnector"
+  ADD COLUMN "authMode" TEXT NOT NULL DEFAULT 'none',
+  ADD COLUMN "authConfigRef" TEXT,
+  ADD COLUMN "authState" TEXT NOT NULL DEFAULT 'not_configured';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,12 @@ model ApiHubConnector {
   name      String
   /// High-level source label until taxonomy lands (e.g. `stub`, `file`, `api`).
   sourceKind String  @default("unspecified")
+  /// Auth mode metadata only (no credential values in this table).
+  authMode  String   @default("none")
+  /// Secret manager / vault reference, never plaintext credentials.
+  authConfigRef String?
+  /// Operator-facing configuration readiness state.
+  authState String   @default("not_configured")
   status    String   @default("draft")
   /// Populated when sync jobs exist; nullable for stub rows.
   lastSyncAt DateTime?

--- a/src/app/api/apihub/connectors/[connectorId]/route.test.ts
+++ b/src/app/api/apihub/connectors/[connectorId]/route.test.ts
@@ -46,6 +46,26 @@ describe("PATCH /api/apihub/connectors/:id", () => {
     });
   });
 
+  it("returns 400 when no update fields are provided", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+
+    const { PATCH } = await import("./route");
+    const response = await PATCH(
+      new Request("http://localhost/api/apihub/connectors/connector-1", {
+        method: "PATCH",
+        body: JSON.stringify({ note: "only note" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      { params: Promise.resolve({ connectorId: "connector-1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Provide at least one update field: status, authMode, authState, authConfigRef, or markSyncedNow.",
+    });
+  });
+
   it("returns 404 when connector is missing", async () => {
     getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
     getActorUserIdMock.mockResolvedValue("actor-1");
@@ -67,6 +87,9 @@ describe("PATCH /api/apihub/connectors/:id", () => {
       actorUserId: "actor-1",
       status: "active",
       syncNow: true,
+      authMode: null,
+      authConfigRef: undefined,
+      authState: null,
       note: "synced",
     });
     expect(response.status).toBe(404);
@@ -78,6 +101,9 @@ describe("PATCH /api/apihub/connectors/:id", () => {
       id: "connector-1",
       name: "ERP feed",
       sourceKind: "stub",
+      authMode: "none",
+      authConfigRef: null,
+      authState: "not_configured",
       status: "paused",
       lastSyncAt: null,
       healthSummary: "Not connected",
@@ -102,5 +128,51 @@ describe("PATCH /api/apihub/connectors/:id", () => {
     expect(response.status).toBe(200);
     expect(toApiHubConnectorDtoMock).toHaveBeenCalledWith(updatedRow);
     expect(await response.json()).toEqual({ connector: { id: "dto-1", status: "paused" } });
+  });
+
+  it("accepts auth config metadata updates", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+    updateApiHubConnectorLifecycleMock.mockResolvedValue({
+      id: "connector-1",
+      name: "ERP feed",
+      sourceKind: "stub",
+      authMode: "api_key_ref",
+      authConfigRef: "secret://demo-company/apihub/erp",
+      authState: "configured",
+      status: "paused",
+      lastSyncAt: null,
+      healthSummary: "Not connected",
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T11:00:00.000Z"),
+    });
+    toApiHubConnectorDtoMock.mockReturnValue({ id: "dto-1", authState: "configured" });
+
+    const { PATCH } = await import("./route");
+    const response = await PATCH(
+      new Request("http://localhost/api/apihub/connectors/connector-1", {
+        method: "PATCH",
+        body: JSON.stringify({
+          authMode: "api_key_ref",
+          authConfigRef: " secret://demo-company/apihub/erp ",
+          authState: "configured",
+        }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      { params: Promise.resolve({ connectorId: "connector-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateApiHubConnectorLifecycleMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      connectorId: "connector-1",
+      actorUserId: "actor-1",
+      status: null,
+      syncNow: false,
+      authMode: "api_key_ref",
+      authConfigRef: "secret://demo-company/apihub/erp",
+      authState: "configured",
+      note: null,
+    });
   });
 });

--- a/src/app/api/apihub/connectors/[connectorId]/route.test.ts
+++ b/src/app/api/apihub/connectors/[connectorId]/route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDemoTenantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const updateApiHubConnectorLifecycleMock = vi.fn();
+const toApiHubConnectorDtoMock = vi.fn();
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/authz", () => ({
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/apihub/connectors-repo", () => ({
+  updateApiHubConnectorLifecycle: updateApiHubConnectorLifecycleMock,
+}));
+
+vi.mock("@/lib/apihub/connector-dto", () => ({
+  toApiHubConnectorDto: toApiHubConnectorDtoMock,
+}));
+
+describe("PATCH /api/apihub/connectors/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for invalid status", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+
+    const { PATCH } = await import("./route");
+    const response = await PATCH(
+      new Request("http://localhost/api/apihub/connectors/connector-1", {
+        method: "PATCH",
+        body: JSON.stringify({ status: "bad-status" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      { params: Promise.resolve({ connectorId: "connector-1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "status must be one of: draft, active, paused, error.",
+    });
+  });
+
+  it("returns 404 when connector is missing", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+    updateApiHubConnectorLifecycleMock.mockResolvedValue(null);
+
+    const { PATCH } = await import("./route");
+    const response = await PATCH(
+      new Request("http://localhost/api/apihub/connectors/connector-1", {
+        method: "PATCH",
+        body: JSON.stringify({ status: "active", markSyncedNow: true, note: "  synced  " }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      { params: Promise.resolve({ connectorId: "connector-1" }) },
+    );
+
+    expect(updateApiHubConnectorLifecycleMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      connectorId: "connector-1",
+      actorUserId: "actor-1",
+      status: "active",
+      syncNow: true,
+      note: "synced",
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Connector not found." });
+  });
+
+  it("returns updated connector dto on success", async () => {
+    const updatedRow = {
+      id: "connector-1",
+      name: "ERP feed",
+      sourceKind: "stub",
+      status: "paused",
+      lastSyncAt: null,
+      healthSummary: "Not connected",
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T11:00:00.000Z"),
+    };
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+    updateApiHubConnectorLifecycleMock.mockResolvedValue(updatedRow);
+    toApiHubConnectorDtoMock.mockReturnValue({ id: "dto-1", status: "paused" });
+
+    const { PATCH } = await import("./route");
+    const response = await PATCH(
+      new Request("http://localhost/api/apihub/connectors/connector-1", {
+        method: "PATCH",
+        body: JSON.stringify({ status: "paused", markSyncedNow: false }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      { params: Promise.resolve({ connectorId: "connector-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(toApiHubConnectorDtoMock).toHaveBeenCalledWith(updatedRow);
+    expect(await response.json()).toEqual({ connector: { id: "dto-1", status: "paused" } });
+  });
+});

--- a/src/app/api/apihub/connectors/[connectorId]/route.ts
+++ b/src/app/api/apihub/connectors/[connectorId]/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 
 import { getActorUserId } from "@/lib/authz";
-import { APIHUB_CONNECTOR_STATUSES } from "@/lib/apihub/constants";
+import {
+  APIHUB_CONNECTOR_AUTH_MODES,
+  APIHUB_CONNECTOR_AUTH_STATES,
+  APIHUB_CONNECTOR_STATUSES,
+} from "@/lib/apihub/constants";
 import { toApiHubConnectorDto } from "@/lib/apihub/connector-dto";
 import { updateApiHubConnectorLifecycle } from "@/lib/apihub/connectors-repo";
 import { getDemoTenant } from "@/lib/demo-tenant";
@@ -9,6 +13,9 @@ import { getDemoTenant } from "@/lib/demo-tenant";
 type PatchBody = {
   status?: unknown;
   markSyncedNow?: unknown;
+  authMode?: unknown;
+  authConfigRef?: unknown;
+  authState?: unknown;
   note?: unknown;
 };
 
@@ -52,8 +59,11 @@ export async function PATCH(
     body = {};
   }
 
-  const rawStatus = typeof body.status === "string" ? body.status.trim().toLowerCase() : "";
-  if (!APIHUB_CONNECTOR_STATUSES.includes(rawStatus as (typeof APIHUB_CONNECTOR_STATUSES)[number])) {
+  const rawStatus = typeof body.status === "string" ? body.status.trim().toLowerCase() : null;
+  if (
+    rawStatus !== null &&
+    !APIHUB_CONNECTOR_STATUSES.includes(rawStatus as (typeof APIHUB_CONNECTOR_STATUSES)[number])
+  ) {
     return NextResponse.json(
       {
         error: `status must be one of: ${APIHUB_CONNECTOR_STATUSES.join(", ")}.`,
@@ -62,8 +72,50 @@ export async function PATCH(
     );
   }
 
+  const rawAuthMode = typeof body.authMode === "string" ? body.authMode.trim().toLowerCase() : null;
+  if (
+    rawAuthMode !== null &&
+    !APIHUB_CONNECTOR_AUTH_MODES.includes(rawAuthMode as (typeof APIHUB_CONNECTOR_AUTH_MODES)[number])
+  ) {
+    return NextResponse.json(
+      {
+        error: `authMode must be one of: ${APIHUB_CONNECTOR_AUTH_MODES.join(", ")}.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const rawAuthState = typeof body.authState === "string" ? body.authState.trim().toLowerCase() : null;
+  if (
+    rawAuthState !== null &&
+    !APIHUB_CONNECTOR_AUTH_STATES.includes(rawAuthState as (typeof APIHUB_CONNECTOR_AUTH_STATES)[number])
+  ) {
+    return NextResponse.json(
+      {
+        error: `authState must be one of: ${APIHUB_CONNECTOR_AUTH_STATES.join(", ")}.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const hasAuthConfigRef = typeof body.authConfigRef === "string" || body.authConfigRef === null;
+  const authConfigRef =
+    typeof body.authConfigRef === "string"
+      ? body.authConfigRef.trim().slice(0, 280) || null
+      : body.authConfigRef === null
+        ? null
+        : undefined;
+
   const markSyncedNow = body.markSyncedNow === true;
   const note = typeof body.note === "string" ? body.note.trim().slice(0, 280) : null;
+  if (rawStatus === null && rawAuthMode === null && rawAuthState === null && !hasAuthConfigRef && !markSyncedNow) {
+    return NextResponse.json(
+      {
+        error: "Provide at least one update field: status, authMode, authState, authConfigRef, or markSyncedNow.",
+      },
+      { status: 400 },
+    );
+  }
 
   const updated = await updateApiHubConnectorLifecycle({
     tenantId: tenant.id,
@@ -71,6 +123,9 @@ export async function PATCH(
     actorUserId: actorId,
     status: rawStatus,
     syncNow: markSyncedNow,
+    authMode: rawAuthMode,
+    authConfigRef,
+    authState: rawAuthState,
     note,
   });
 

--- a/src/app/api/apihub/connectors/route.test.ts
+++ b/src/app/api/apihub/connectors/route.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDemoTenantMock = vi.fn();
+const getActorUserIdMock = vi.fn();
+const listApiHubConnectorsMock = vi.fn();
+const listApiHubConnectorAuditLogsMock = vi.fn();
+const createStubApiHubConnectorMock = vi.fn();
+const toApiHubConnectorDtoMock = vi.fn();
+
+vi.mock("@/lib/demo-tenant", () => ({
+  getDemoTenant: getDemoTenantMock,
+}));
+
+vi.mock("@/lib/authz", () => ({
+  getActorUserId: getActorUserIdMock,
+}));
+
+vi.mock("@/lib/apihub/connectors-repo", () => ({
+  listApiHubConnectors: listApiHubConnectorsMock,
+  listApiHubConnectorAuditLogs: listApiHubConnectorAuditLogsMock,
+  createStubApiHubConnector: createStubApiHubConnectorMock,
+}));
+
+vi.mock("@/lib/apihub/connector-dto", () => ({
+  toApiHubConnectorDto: toApiHubConnectorDtoMock,
+}));
+
+describe("GET /api/apihub/connectors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when demo tenant is missing", async () => {
+    getDemoTenantMock.mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "Demo tenant not found. Run `npm run db:seed` to create starter data.",
+    });
+  });
+
+  it("returns 403 when actor is missing", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "No active demo user for this session. Open Settings → Demo session (/settings/demo) to choose who you are acting as.",
+    });
+  });
+
+  it("returns connector rows with audit logs", async () => {
+    const row = {
+      id: "connector-1",
+      name: "Carrier feed",
+      sourceKind: "stub",
+      status: "draft",
+      lastSyncAt: null,
+      healthSummary: "ok",
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+    };
+    const audit = {
+      id: "audit-1",
+      connectorId: "connector-1",
+      actorUserId: "actor-1",
+      action: "connector.created",
+      note: "Created",
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+    };
+
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+    listApiHubConnectorsMock.mockResolvedValue([row]);
+    listApiHubConnectorAuditLogsMock.mockResolvedValue([audit]);
+    toApiHubConnectorDtoMock.mockReturnValue({ id: "dto-1" });
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(listApiHubConnectorsMock).toHaveBeenCalledWith("tenant-1");
+    expect(listApiHubConnectorAuditLogsMock).toHaveBeenCalledWith("tenant-1", "connector-1", 3);
+    expect(toApiHubConnectorDtoMock).toHaveBeenCalledWith(
+      {
+        ...row,
+        auditLogs: [audit],
+      },
+      0,
+      expect.any(Array),
+    );
+    expect(await response.json()).toEqual({ connectors: [{ id: "dto-1" }] });
+  });
+});
+
+describe("POST /api/apihub/connectors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a connector with trimmed and capped name", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+    createStubApiHubConnectorMock.mockResolvedValue({
+      id: "connector-1",
+      name: "New connector",
+      sourceKind: "stub",
+      status: "draft",
+      lastSyncAt: null,
+      healthSummary: null,
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+    });
+    toApiHubConnectorDtoMock.mockReturnValue({ id: "dto-1" });
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/apihub/connectors", {
+        method: "POST",
+        body: JSON.stringify({ name: "   New connector   " }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(createStubApiHubConnectorMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      actorUserId: "actor-1",
+      name: "New connector",
+    });
+    expect(await response.json()).toEqual({ connector: { id: "dto-1" } });
+  });
+
+  it("uses default name when payload is invalid json", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+    createStubApiHubConnectorMock.mockResolvedValue({
+      id: "connector-1",
+      name: "Stub connector",
+      sourceKind: "stub",
+      status: "draft",
+      lastSyncAt: null,
+      healthSummary: null,
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+    });
+    toApiHubConnectorDtoMock.mockReturnValue({ id: "dto-1" });
+
+    const { POST } = await import("./route");
+    await POST(
+      new Request("http://localhost/api/apihub/connectors", {
+        method: "POST",
+        body: "{not json",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(createStubApiHubConnectorMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      actorUserId: "actor-1",
+      name: "Stub connector",
+    });
+  });
+});

--- a/src/app/api/apihub/connectors/route.test.ts
+++ b/src/app/api/apihub/connectors/route.test.ts
@@ -60,6 +60,9 @@ describe("GET /api/apihub/connectors", () => {
       id: "connector-1",
       name: "Carrier feed",
       sourceKind: "stub",
+      authMode: "none",
+      authConfigRef: null,
+      authState: "not_configured",
       status: "draft",
       lastSyncAt: null,
       healthSummary: "ok",
@@ -111,6 +114,9 @@ describe("POST /api/apihub/connectors", () => {
       id: "connector-1",
       name: "New connector",
       sourceKind: "stub",
+      authMode: "none",
+      authConfigRef: null,
+      authState: "not_configured",
       status: "draft",
       lastSyncAt: null,
       healthSummary: null,
@@ -133,8 +139,73 @@ describe("POST /api/apihub/connectors", () => {
       tenantId: "tenant-1",
       actorUserId: "actor-1",
       name: "New connector",
+      authMode: "none",
+      authConfigRef: null,
+      authState: "not_configured",
     });
     expect(await response.json()).toEqual({ connector: { id: "dto-1" } });
+  });
+
+  it("accepts auth metadata without storing secrets", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+    createStubApiHubConnectorMock.mockResolvedValue({
+      id: "connector-1",
+      name: "ERP feed",
+      sourceKind: "stub",
+      authMode: "api_key_ref",
+      authConfigRef: "secret://demo-company/apihub/erp",
+      authState: "configured",
+      status: "draft",
+      lastSyncAt: null,
+      healthSummary: null,
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+    });
+    toApiHubConnectorDtoMock.mockReturnValue({ id: "dto-1" });
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/apihub/connectors", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "ERP feed",
+          authMode: "api_key_ref",
+          authConfigRef: " secret://demo-company/apihub/erp ",
+          authState: "configured",
+        }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(createStubApiHubConnectorMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      actorUserId: "actor-1",
+      name: "ERP feed",
+      authMode: "api_key_ref",
+      authConfigRef: "secret://demo-company/apihub/erp",
+      authState: "configured",
+    });
+  });
+
+  it("returns 400 for unsupported auth mode", async () => {
+    getDemoTenantMock.mockResolvedValue({ id: "tenant-1" });
+    getActorUserIdMock.mockResolvedValue("actor-1");
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/apihub/connectors", {
+        method: "POST",
+        body: JSON.stringify({ authMode: "plaintext_token" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "authMode must be one of: none, api_key_ref, oauth_client_ref, basic_ref.",
+    });
   });
 
   it("uses default name when payload is invalid json", async () => {
@@ -144,6 +215,9 @@ describe("POST /api/apihub/connectors", () => {
       id: "connector-1",
       name: "Stub connector",
       sourceKind: "stub",
+      authMode: "none",
+      authConfigRef: null,
+      authState: "not_configured",
       status: "draft",
       lastSyncAt: null,
       healthSummary: null,
@@ -165,6 +239,9 @@ describe("POST /api/apihub/connectors", () => {
       tenantId: "tenant-1",
       actorUserId: "actor-1",
       name: "Stub connector",
+      authMode: "none",
+      authConfigRef: null,
+      authState: "not_configured",
     });
   });
 });

--- a/src/app/api/apihub/connectors/route.ts
+++ b/src/app/api/apihub/connectors/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { APIHUB_CONNECTOR_AUTH_MODES, APIHUB_CONNECTOR_AUTH_STATES } from "@/lib/apihub/constants";
 import { toApiHubConnectorDto } from "@/lib/apihub/connector-dto";
 import {
   createStubApiHubConnector,
@@ -46,6 +47,9 @@ export async function GET() {
 
 type PostBody = {
   name?: unknown;
+  authMode?: unknown;
+  authConfigRef?: unknown;
+  authState?: unknown;
 };
 
 export async function POST(request: Request) {
@@ -80,7 +84,37 @@ export async function POST(request: Request) {
 
   const rawName = typeof body.name === "string" ? body.name.trim() : "";
   const name = rawName.length > 0 ? rawName.slice(0, 128) : "Stub connector";
+  const rawAuthMode = typeof body.authMode === "string" ? body.authMode.trim().toLowerCase() : "none";
+  if (!APIHUB_CONNECTOR_AUTH_MODES.includes(rawAuthMode as (typeof APIHUB_CONNECTOR_AUTH_MODES)[number])) {
+    return NextResponse.json(
+      {
+        error: `authMode must be one of: ${APIHUB_CONNECTOR_AUTH_MODES.join(", ")}.`,
+      },
+      { status: 400 },
+    );
+  }
+  const rawAuthState =
+    typeof body.authState === "string" ? body.authState.trim().toLowerCase() : "not_configured";
+  if (!APIHUB_CONNECTOR_AUTH_STATES.includes(rawAuthState as (typeof APIHUB_CONNECTOR_AUTH_STATES)[number])) {
+    return NextResponse.json(
+      {
+        error: `authState must be one of: ${APIHUB_CONNECTOR_AUTH_STATES.join(", ")}.`,
+      },
+      { status: 400 },
+    );
+  }
+  const authConfigRef =
+    typeof body.authConfigRef === "string" && body.authConfigRef.trim().length > 0
+      ? body.authConfigRef.trim().slice(0, 280)
+      : null;
 
-  const created = await createStubApiHubConnector({ tenantId: tenant.id, actorUserId: actorId, name });
+  const created = await createStubApiHubConnector({
+    tenantId: tenant.id,
+    actorUserId: actorId,
+    name,
+    authMode: rawAuthMode,
+    authConfigRef,
+    authState: rawAuthState,
+  });
   return NextResponse.json({ connector: toApiHubConnectorDto(created) }, { status: 201 });
 }

--- a/src/app/api/apihub/health/route.test.ts
+++ b/src/app/api/apihub/health/route.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+describe("GET /api/apihub/health", () => {
+  it("returns API Hub health payload", async () => {
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      service: "apihub",
+      phase: "P2",
+    });
+  });
+});

--- a/src/lib/apihub/connector-dto.test.ts
+++ b/src/lib/apihub/connector-dto.test.ts
@@ -10,6 +10,9 @@ describe("toApiHubConnectorDto", () => {
       id: "c1",
       name: "Test",
       sourceKind: "stub",
+      authMode: "none",
+      authConfigRef: null,
+      authState: "not_configured",
       status: "draft",
       lastSyncAt: null,
       healthSummary: "ok",
@@ -20,6 +23,9 @@ describe("toApiHubConnectorDto", () => {
     expect(out.createdAt).toBe("2026-04-20T12:00:00.000Z");
     expect(out.updatedAt).toBe("2026-04-20T15:30:00.000Z");
     expect(out.healthSummary).toBe("ok");
+    expect(out.authMode).toBe("none");
+    expect(out.authConfigRef).toBeNull();
+    expect(out.authState).toBe("not_configured");
     expect(out.auditTrail).toEqual([]);
   });
 
@@ -28,6 +34,9 @@ describe("toApiHubConnectorDto", () => {
       id: "c2",
       name: "ERP feed",
       sourceKind: "api",
+      authMode: "api_key_ref",
+      authConfigRef: "secret://tenant/erp",
+      authState: "configured",
       status: "active",
       lastSyncAt: new Date("2026-04-21T09:00:00.000Z"),
       healthSummary: "Healthy",

--- a/src/lib/apihub/connector-dto.ts
+++ b/src/lib/apihub/connector-dto.ts
@@ -2,6 +2,9 @@ export type ApiHubConnectorDto = {
   id: string;
   name: string;
   sourceKind: string;
+  authMode: string;
+  authConfigRef: string | null;
+  authState: string;
   status: string;
   lastSyncAt: string | null;
   healthSummary: string | null;
@@ -22,6 +25,9 @@ type Row = {
   id: string;
   name: string;
   sourceKind: string;
+  authMode: string;
+  authConfigRef: string | null;
+  authState: string;
   status: string;
   lastSyncAt: Date | null;
   healthSummary: string | null;
@@ -41,6 +47,9 @@ export function toApiHubConnectorDto(row: Row): ApiHubConnectorDto {
     id: row.id,
     name: row.name,
     sourceKind: row.sourceKind,
+    authMode: row.authMode,
+    authConfigRef: row.authConfigRef,
+    authState: row.authState,
     status: row.status,
     lastSyncAt: row.lastSyncAt ? row.lastSyncAt.toISOString() : null,
     healthSummary: row.healthSummary,

--- a/src/lib/apihub/connectors-repo.ts
+++ b/src/lib/apihub/connectors-repo.ts
@@ -6,6 +6,9 @@ export type ApiHubConnectorListRow = {
   id: string;
   name: string;
   sourceKind: string;
+  authMode: string;
+  authConfigRef: string | null;
+  authState: string;
   status: string;
   lastSyncAt: Date | null;
   healthSummary: string | null;
@@ -30,6 +33,9 @@ export async function listApiHubConnectors(tenantId: string): Promise<ApiHubConn
       id: true,
       name: true,
       sourceKind: true,
+      authMode: true,
+      authConfigRef: true,
+      authState: true,
       status: true,
       lastSyncAt: true,
       healthSummary: true,
@@ -43,6 +49,9 @@ export async function createStubApiHubConnector(opts: {
   tenantId: string;
   actorUserId: string;
   name: string;
+  authMode: string;
+  authConfigRef: string | null;
+  authState: string;
 }): Promise<ApiHubConnectorListRow> {
   return prisma.$transaction(async (tx) => {
     const created = await tx.apiHubConnector.create({
@@ -50,6 +59,9 @@ export async function createStubApiHubConnector(opts: {
         tenantId: opts.tenantId,
         name: opts.name,
         sourceKind: "stub",
+        authMode: opts.authMode,
+        authConfigRef: opts.authConfigRef,
+        authState: opts.authState,
         status: "draft",
         healthSummary: DEFAULT_STUB_HEALTH,
       },
@@ -57,6 +69,9 @@ export async function createStubApiHubConnector(opts: {
         id: true,
         name: true,
         sourceKind: true,
+        authMode: true,
+        authConfigRef: true,
+        authState: true,
         status: true,
         lastSyncAt: true,
         healthSummary: true,
@@ -83,14 +98,17 @@ export async function updateApiHubConnectorLifecycle(opts: {
   tenantId: string;
   connectorId: string;
   actorUserId: string;
-  status: string;
+  status: string | null;
   syncNow: boolean;
+  authMode: string | null;
+  authConfigRef: string | null | undefined;
+  authState: string | null;
   note: string | null;
 }): Promise<ApiHubConnectorListRow | null> {
   return prisma.$transaction(async (tx) => {
     const existing = await tx.apiHubConnector.findFirst({
       where: { id: opts.connectorId, tenantId: opts.tenantId },
-      select: { id: true, status: true },
+      select: { id: true, status: true, authMode: true, authConfigRef: true, authState: true },
     });
     if (!existing) {
       return null;
@@ -99,13 +117,19 @@ export async function updateApiHubConnectorLifecycle(opts: {
     const updated = await tx.apiHubConnector.update({
       where: { id: existing.id },
       data: {
-        status: opts.status,
+        ...(opts.status ? { status: opts.status } : {}),
+        ...(opts.authMode ? { authMode: opts.authMode } : {}),
+        ...(opts.authConfigRef !== undefined ? { authConfigRef: opts.authConfigRef } : {}),
+        ...(opts.authState ? { authState: opts.authState } : {}),
         ...(opts.syncNow ? { lastSyncAt: new Date() } : {}),
       },
       select: {
         id: true,
         name: true,
         sourceKind: true,
+        authMode: true,
+        authConfigRef: true,
+        authState: true,
         status: true,
         lastSyncAt: true,
         healthSummary: true,
@@ -122,7 +146,7 @@ export async function updateApiHubConnectorLifecycle(opts: {
         action: "connector.lifecycle.updated",
         note:
           opts.note ??
-          `Status ${existing.status} -> ${opts.status}${opts.syncNow ? " (sync timestamp set)" : ""}`,
+          `Status ${existing.status} -> ${opts.status ?? existing.status}; auth ${existing.authMode}/${existing.authState} -> ${opts.authMode ?? existing.authMode}/${opts.authState ?? existing.authState}${opts.syncNow ? " (sync timestamp set)" : ""}`,
       },
     });
 

--- a/src/lib/apihub/constants.ts
+++ b/src/lib/apihub/constants.ts
@@ -7,3 +7,11 @@ export const APIHUB_PHASE = "P2" as const;
 /** Narrow lifecycle enum for Phase 2 connector registry updates. */
 export const APIHUB_CONNECTOR_STATUSES = ["draft", "active", "paused", "error"] as const;
 export type ApiHubConnectorStatus = (typeof APIHUB_CONNECTOR_STATUSES)[number];
+
+/** Non-secret auth mode metadata for connector setup. */
+export const APIHUB_CONNECTOR_AUTH_MODES = ["none", "api_key_ref", "oauth_client_ref", "basic_ref"] as const;
+export type ApiHubConnectorAuthMode = (typeof APIHUB_CONNECTOR_AUTH_MODES)[number];
+
+/** Operator-visible auth setup readiness states. */
+export const APIHUB_CONNECTOR_AUTH_STATES = ["not_configured", "configured", "error"] as const;
+export type ApiHubConnectorAuthState = (typeof APIHUB_CONNECTOR_AUTH_STATES)[number];

--- a/src/lib/apihub/constants.ts
+++ b/src/lib/apihub/constants.ts
@@ -1,8 +1,8 @@
 /** Stable service id for health payloads and logging. */
 export const APIHUB_SERVICE = "apihub" as const;
 
-/** Current shipped phase label (P0 = docs + shell + health stub only). */
-export const APIHUB_PHASE = "P0" as const;
+/** Current shipped phase label for health/discovery payloads. */
+export const APIHUB_PHASE = "P2" as const;
 
 /** Narrow lifecycle enum for Phase 2 connector registry updates. */
 export const APIHUB_CONNECTOR_STATUSES = ["draft", "active", "paused", "error"] as const;

--- a/src/lib/apihub/health-body.test.ts
+++ b/src/lib/apihub/health-body.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import { getApiHubHealthJson } from "./health-body";
 
 describe("getApiHubHealthJson", () => {
-  it("returns the P0 health contract", () => {
+  it("returns the API Hub health contract", () => {
     expect(getApiHubHealthJson()).toEqual({
       ok: true,
       service: "apihub",
-      phase: "P0",
+      phase: "P2",
     });
   });
 });


### PR DESCRIPTION
## Summary
- complete M1 for API Hub real implementation by locking route contracts with new Vitest coverage for `GET/POST /api/apihub/connectors`, `PATCH /api/apihub/connectors/:id`, and `GET /api/apihub/health`
- align API Hub health payload phase constant from `P0` to `P2` to match shipped connector lifecycle + audit slice
- keep all changes scoped to API Hub paths only

## Validation
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/lib/apihub/health-body.test.ts src/lib/apihub/connector-dto.test.ts src/app/api/apihub/health/route.test.ts src/app/api/apihub/connectors/route.test.ts "src/app/api/apihub/connectors/[connectorId]/route.test.ts"`

## Milestone status
- [x] M1 complete
- [ ] M2
- [ ] M3
- [ ] M4
- [ ] M5
- [ ] M6

## Risks / follow-ups
- lint reports pre-existing warnings outside API Hub scope (`src/components/control-tower-shipment-360.tsx`, `src/components/supplier-detail-client.tsx`)
- next milestone should focus on incremental backend capability (not UI-only stubs), while preserving existing demo UX behind current flags/states

Made with [Cursor](https://cursor.com)